### PR TITLE
feat(scheduler-service): SFO-101 add ext_id along with calendar create

### DIFF
--- a/services/scheduler-service/src/models/calendar.dto.ts
+++ b/services/scheduler-service/src/models/calendar.dto.ts
@@ -56,6 +56,18 @@ export class CalendarDTO extends Model {
   })
   timezone?: string;
 
+  @property({
+    type: 'string',
+    name: 'ext_id',
+  })
+  extId?: string;
+
+  @property({
+    type: 'object',
+    name: 'ext_metadata',
+  })
+  extMetadata?: object;
+
   @property.array(WorkingHour)
   workingHours?: WorkingHour[];
 


### PR DESCRIPTION
SFO-101

## Description

- Add the ability to add ext_id and ext_metadata along with calendar post request.

Fixes # (SFO-101)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] postman

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
