### PR TITLE
feat(authentication-service): validate access token

### DIFF
--- a/services/authentication-service/src/__tests__/acceptance/auth.acceptance.ts
+++ b/services/authentication-service/src/__tests__/acceptance/auth.acceptance.ts
@@ -200,8 +200,52 @@ describe('Authentication microservice', () => {
     });
     const response = await client
       .post(`/auth/token-refresh`)
-      .send({refreshToken: reqForToken.body.refreshToken});
+      .send({refreshToken: reqForToken.body.refreshToken})
+      .set('Authorization', `Bearer ${reqForToken.body.accessToken}`);
     expect(response.body).to.have.properties(['accessToken', 'refreshToken']);
+  });
+  it('should return 401 for token refresh request when Authentication token invalid', async () => {
+    const reqData = {
+      // eslint-disable-next-line
+      client_id: 'web', // eslint-disable-next-line
+      client_secret: 'test',
+      username: 'test_user',
+      password: 'temp123!@',
+    };
+    const reqForCode = await client
+      .post(`/auth/login`)
+      .send(reqData)
+      .expect(200);
+    const reqForToken = await client.post(`/auth/token`).send({
+      clientId: 'web',
+      code: reqForCode.body.code,
+    });
+    await client
+      .post(`/auth/token-refresh`)
+      .send({refreshToken: reqForToken.body.refreshToken})
+      .set('Authorization', 'Bearer abc')
+      .expect(401);
+  });
+  it('should return 401 for token refresh request when Authentication token missing', async () => {
+    const reqData = {
+      // eslint-disable-next-line
+      client_id: 'web', // eslint-disable-next-line
+      client_secret: 'test',
+      username: 'test_user',
+      password: 'temp123!@',
+    };
+    const reqForCode = await client
+      .post(`/auth/login`)
+      .send(reqData)
+      .expect(200);
+    const reqForToken = await client.post(`/auth/token`).send({
+      clientId: 'web',
+      code: reqForCode.body.code,
+    });
+    await client
+      .post(`/auth/token-refresh`)
+      .send({refreshToken: reqForToken.body.refreshToken})
+      .expect(401);
   });
   it('should send forgot password request successfully', async () => {
     const reqData = {

--- a/services/authentication-service/src/modules/auth/login.controller.ts
+++ b/services/authentication-service/src/modules/auth/login.controller.ts
@@ -311,6 +311,7 @@ export class LoginController {
   async exchangeToken(
     @requestBody() req: AuthRefreshTokenRequest,
     @param.header.string('device_id') deviceId?: string,
+    @param.header.string('Authorization') token?: string,
   ): Promise<TokenResponse> {
     const refreshPayload: RefreshToken = await this.refreshTokenRepo.get(
       req.refreshToken,
@@ -325,6 +326,10 @@ export class LoginController {
     });
     if (!authClient) {
       throw new HttpErrors.Unauthorized(AuthErrorKeys.ClientInvalid);
+    }
+    const accessToken = token?.split(" ")[1];
+    if (!accessToken || refreshPayload.accessToken !== accessToken) {
+      throw new HttpErrors.Unauthorized(AuthErrorKeys.TokenInvalid);
     }
     await this.revokedTokensRepo.set(refreshPayload.accessToken, {
       token: refreshPayload.accessToken,

--- a/services/authentication-service/src/modules/auth/login.controller.ts
+++ b/services/authentication-service/src/modules/auth/login.controller.ts
@@ -327,7 +327,7 @@ export class LoginController {
     if (!authClient) {
       throw new HttpErrors.Unauthorized(AuthErrorKeys.ClientInvalid);
     }
-    const accessToken = token?.split(" ")[1];
+    const accessToken = token?.split(' ')[1];
     if (!accessToken || refreshPayload.accessToken !== accessToken) {
       throw new HttpErrors.Unauthorized(AuthErrorKeys.TokenInvalid);
     }


### PR DESCRIPTION
## Description

**Issue:** The Auth-token, i.e: JWT Token, is not being verified in refresh-token request. The new Auth & Refresh
Tokens can be fetched without passing the Authorization Token in request

**Solution:** Validate and map the Authorization token with the refresh-token being passed in the request before providing
the new tokens.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
