### PR TITLE
fix(core): add prom client installation step in core readme

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,3 +26,9 @@ that are used throughout the service catalog.
 ```bash
 npm install @sourcelooop/core
 ```
+
+`@sourceloop/core` is dependent on [`swagger-stats`](https://www.npmjs.com/package/swagger-stats), so if you haven't added prom-client already, you should do this now. It's a peer dependency of swagger-stats as of version 0.95.19.
+
+```bash
+npm install prom-client@12 --save
+```


### PR DESCRIPTION
## Description

Add `prom-client` installation steps in readme of @sourceloop/core because - 

- it is a peer-dependecy of swagger-stats since version [0.95.19](https://github.com/slanatech/swagger-stats/releases/tag/v0.95.19).
- npm 3-6 does not install peer dependencies automatically.

Fixes GH-282

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the style guide
- [X] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
