### PR TITLE
fix: Token not working from swagger

### DIFF
--- a/services/authentication-service/src/modules/auth/login.controller.ts
+++ b/services/authentication-service/src/modules/auth/login.controller.ts
@@ -278,6 +278,7 @@ export class LoginController {
 
   @authorize({permissions: ['*']})
   @post('/auth/token-refresh', {
+    security: OPERATION_SECURITY_SPEC,
     description:
       'Gets you a new access and refresh token once your access token is expired. (both mobile and web)\n',
     responses: {


### PR DESCRIPTION
## Description

Added bearer authorization scope to /auth/token-refresh endpoint.
Swagger will now add Authorization bearer header to the request.

## Issues Fixed

Fixes #361 