### PR TITLE
fix(search-service): handle case in which match has whitespaces

### DIFF
--- a/services/search-service/src/controllers/search.controller.ts
+++ b/services/search-service/src/controllers/search.controller.ts
@@ -81,6 +81,7 @@ export function defineSearchController<T extends Model>(
         }
       }
       query.where = filter;
+      query.match = query.match.trim();
       return this.searchFn(query);
     }
 


### PR DESCRIPTION
## Description

In case match parameter has whitespaces returning status code 400 with missing match parameter message

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
