### PR TITLE
fix(user-onboarding): add option to exit tour on pressing esc, add hide tour function

### DIFF
--- a/packages/user-onboarding/projects/user-onboarding-lib/src/lib/tour-service.service.ts
+++ b/packages/user-onboarding/projects/user-onboarding-lib/src/lib/tour-service.service.ts
@@ -26,6 +26,7 @@ export class TourServiceService {
   tourStepChange$ = this.tourStepChange.asObservable();
   private readonly interval = INTERVAL;
   private _maxWaitTime = DEFAULT_MAX_WAIT_TIME;
+  private _exitOnEsc = true;
   private readonly tourFailed = new Subject<{
     tourId: string;
     message: string;
@@ -47,6 +48,14 @@ export class TourServiceService {
 
   public get maxWaitTime() {
     return this._maxWaitTime;
+  }
+
+  public set exitOnEsc(esc: boolean) {
+    this._exitOnEsc = esc;
+  }
+
+  public get exitOnEsc() {
+    return this._exitOnEsc;
   }
   private addRemovedSteps(removedSteps): void {
     const count = removedSteps.length;
@@ -280,6 +289,7 @@ export class TourServiceService {
         }
         this.tour = new Shepherd.Tour({
           useModalOverlay: true,
+          exitOnEsc: this._exitOnEsc,
           defaultStepOptions: {
             cancelIcon: {
               enabled: true,
@@ -299,6 +309,9 @@ export class TourServiceService {
         }
         this.triggerTour(tourInstance, props);
       });
+  }
+  public hideTour() {
+    this.tour.hide();
   }
   private checkElement(attachTo: TourStep['attachTo']) {
     switch (attachTo.type) {


### PR DESCRIPTION
## Description

- Shepherd by default exits tour on pressing escape but this can be changed while creating tour - provided the same option to user, user can set/unset exitOnEsc property to enable/disable this behaviour.
- Added a function to hide tour - there can be a scenario where user wants to hide the tour.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)


## Checklist:

- [x] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
