### PR TITLE
fix(user-onboarding): user gets blocked on pressing esc key - TourCancel event emitted for the same

### DIFF
--- a/packages/user-onboarding/projects/user-onboarding-lib/src/lib/tour-service.service.ts
+++ b/packages/user-onboarding/projects/user-onboarding-lib/src/lib/tour-service.service.ts
@@ -11,6 +11,7 @@ import {
   Status,
   TourStepChange,
   TourComplete,
+  TourCancel,
 } from '../models';
 import {Router, NavigationEnd, Event as NavigationEvent} from '@angular/router';
 import {Subject} from 'rxjs';
@@ -24,6 +25,8 @@ export class TourServiceService {
   tourComplete$ = this.tourComplete.asObservable();
   private readonly tourStepChange = new Subject<TourStepChange>();
   tourStepChange$ = this.tourStepChange.asObservable();
+  private readonly tourCancel = new Subject<TourCancel>();
+  tourCancel$ = this.tourCancel.asObservable();
   private readonly interval = INTERVAL;
   private _maxWaitTime = DEFAULT_MAX_WAIT_TIME;
   private _exitOnEsc = true;
@@ -301,6 +304,13 @@ export class TourServiceService {
           event.tourId = tourInstance.tourId;
           this.tourComplete.next(event);
         });
+
+        // on pressing esc cancel event is emitted by shepherd
+        this.tour.on('cancel', (event: TourCancel) => {
+          event.tourId = tourInstance.tourId;
+          this.tourCancel.next(event);
+        });
+
         if (filterFn) {
           tourInstance.tourSteps = filterFn(tourInstance.tourSteps);
         }
@@ -350,7 +360,7 @@ export class TourServiceService {
   private pauseAllVideos() {
     document.querySelectorAll('video').forEach(vid => vid.pause());
   }
-  private setTourComplete(tourId: string, props: Props) {
+  setTourComplete(tourId: string, props: Props) {
     this.tourStoreService
       .saveState({
         tourId,

--- a/packages/user-onboarding/projects/user-onboarding-lib/src/models/index.ts
+++ b/packages/user-onboarding/projects/user-onboarding-lib/src/models/index.ts
@@ -10,3 +10,4 @@ export * from './props';
 export * from './status';
 export * from './tour-step-change';
 export * from './tour-complete';
+export * from './tour-cancel';

--- a/packages/user-onboarding/projects/user-onboarding-lib/src/models/tour-cancel.ts
+++ b/packages/user-onboarding/projects/user-onboarding-lib/src/models/tour-cancel.ts
@@ -1,0 +1,7 @@
+import Shepherd from 'shepherd.js';
+
+export type TourCancel = {
+  index: number;
+  tour: Shepherd.Tour;
+  tourId: string;
+};


### PR DESCRIPTION
- Shepherd emits cancel event when user presses esc key in case exitOnEsc is set to true. Have emitted similar cancel event for user.
- Also have made setTourComplete function public so that user can directly access and would not have to write himself.
gh-0

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
