### PR TITLE
docs(cache): restructure README.md and remove salt option

### DIFF
--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -28,6 +28,7 @@ export interface ICacheMixin<M extends Entity, ID> {
 
 export interface ICacheMixinOptions {
   ttl?: number;
+  scanCount?: number;
 }
 
 export interface ICacheFindOptions {


### PR DESCRIPTION
## Description

- Restructured readme :
  - changed from paragraph to bullet points
  - added table for cache options
  - added sheild badges for downloads, node verison, @loopback/core version
  - made it more brief and precise 
- Removed Salt from cache options.
- Added scanCount to cache options

Fixes # (gh-853)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [ ] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [x] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
