### PR TITLE
fix(cache): override findOne method and add caching to it

### DIFF
--- a/packages/cache/src/mixins/cache.mixin.ts
+++ b/packages/cache/src/mixins/cache.mixin.ts
@@ -9,6 +9,7 @@ import {
   Filter,
   FilterExcludingWhere,
   JugglerDataSource,
+  Options,
 } from '@loopback/repository';
 import {HttpErrors} from '@loopback/rest';
 import * as crypto from 'crypto';
@@ -117,6 +118,38 @@ export class CacheManager {
           }
         }
 
+        return finalResult;
+      }
+
+      /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+      // @ts-ignore
+      async findOne(
+        filter?: Filter<M>,
+        options?: Options,
+      ): Promise<(M & Relations) | null> {
+        this.checkDataSource();
+        const key = await this.generateKey(undefined, filter);
+        let finalResult: (M & Relations) | null;
+        if (options?.forceUpdate) {
+          finalResult = await super.findOne(filter, options);
+          this.strategy
+            .saveInCache(key, finalResult, cacheOptions)
+            .catch(err => console.error(err)); //NOSONAR
+        } else {
+          const result = (await this.strategy.searchInCache(
+            key,
+            cacheOptions,
+          )) as (M & Relations) | null;
+          // check is only for undefined as result of type null can also be stored in cache
+          if (result !== undefined) {
+            finalResult = result;
+          } else {
+            finalResult = await super.findOne(filter, options);
+            this.strategy
+              .saveInCache(key, finalResult, cacheOptions)
+              .catch(err => console.error(err)); //NOSONAR
+          }
+        }
         return finalResult;
       }
 

--- a/packages/cache/src/strategies/cache-strategy.ts
+++ b/packages/cache/src/strategies/cache-strategy.ts
@@ -10,10 +10,10 @@ export interface ICacheStrategy<M> extends CachePluginComponentOptions {
   searchInCache(
     key: string,
     cacheOptions: ICacheMixinOptions,
-  ): Promise<M | M[] | undefined>;
+  ): Promise<M | M[] | undefined | null>;
   saveInCache(
     key: string,
-    value: M | M[],
+    value: M | M[] | null,
     cacheOptions: ICacheMixinOptions,
   ): Promise<void>;
   clearCache(cacheOptions: ICacheMixinOptions): Promise<void>;

--- a/packages/cache/src/strategies/redis/redis-cache-strategy.ts
+++ b/packages/cache/src/strategies/redis/redis-cache-strategy.ts
@@ -29,8 +29,8 @@ export class RedisCacheStrategy<M> implements ICacheStrategy<M> {
   async searchInCache(
     key: string,
     cacheOptions: IRedisCacheMixinOptions,
-  ): Promise<M | M[] | undefined> {
-    let result: M | M[] | undefined;
+  ): Promise<M | M[] | undefined | null> {
+    let result: M | M[] | undefined | null;
     try {
       const res = (await this.executeRedisCommand('GET', [key])) as Buffer;
       if (res) {
@@ -46,7 +46,7 @@ export class RedisCacheStrategy<M> implements ICacheStrategy<M> {
 
   async saveInCache(
     key: string,
-    value: M | M[],
+    value: M | M[] | null,
     cacheOptions: IRedisCacheMixinOptions,
   ): Promise<void> {
     try {


### PR DESCRIPTION

## Description

- Caching was not done for findOne method. Fixed that. 
- Find One method can return null as response. Null responses are also stored in cache. Changed types for strategy interface accordingly.

Fixes # (gh-0)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)


## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
