### PR TITLE
docs(cli): fix source code links

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,12 +2,12 @@
 
 This is a `sourceloop` based cli that provides commands to scaffold a monorepo, add extensiona, facades and microservices to it.
 
-## Building
+## Installation
 
-To install sourceloop-cli, run
+To install sourceloop cli, run
 
 ```shell
-npm install @sourceloop/cli
+npm install -g @sourceloop/cli
 ```
 
 ## Usage
@@ -73,7 +73,7 @@ OPTIONS
   --help  show manual pages
 ```
 
-_See code: [src/commands/extension.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/v2.4.5/src/commands/extension.ts)_
+_See code: [src/commands/extension.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/master/packages/cli/src/commands/extension.ts)_
 
 ## `sl microservice [NAME]`
 
@@ -117,7 +117,7 @@ OPTIONS
       Include base microservice migrations
 ```
 
-_See code: [src/commands/microservice.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/v2.4.5/src/commands/microservice.ts)_
+_See code: [src/commands/microservice.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/master/packages/cli/src/commands/microservice.ts)_
 
 ## `sl scaffold [NAME]`
 
@@ -139,7 +139,7 @@ OPTIONS
   --owner=owner              owner of the repo
 ```
 
-_See code: [src/commands/scaffold.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/v2.4.5/src/commands/scaffold.ts)_
+_See code: [src/commands/scaffold.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/master/packages/cli/src/commands/scaffold.ts)_
 
 ## `sl update`
 
@@ -153,5 +153,5 @@ OPTIONS
   --help  show manual pages
 ```
 
-_See code: [src/commands/update.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/v2.4.5/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/master/packages/cli/src/commands/update.ts)_
 <!-- commandsstop -->


### PR DESCRIPTION
Updated broken source file links pointing to 404 in `packages/cli/README.md`.