### PR TITLE
fix(cli): error handling if the base service does not have migrations

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,27 +13,30 @@ npm install @sourceloop/cli
 ## Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @sourceloop/cli
 $ sl COMMAND
 running command...
 $ sl (-v|--version|version)
-@sourceloop/cli/3.0.9 linux-x64 node-v16.13.1
+@sourceloop/cli/3.0.1 linux-x64 node-v16.14.2
 $ sl --help [COMMAND]
 USAGE
   $ sl COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 ## Commands
 
 <!-- commands -->
-* [`sl autocomplete [SHELL]`](#sl-autocomplete-shell)
-* [`sl extension [NAME]`](#sl-extension-name)
-* [`sl microservice [NAME]`](#sl-microservice-name)
-* [`sl scaffold [NAME]`](#sl-scaffold-name)
-* [`sl update`](#sl-update)
+
+- [`sl autocomplete [SHELL]`](#sl-autocomplete-shell)
+- [`sl extension [NAME]`](#sl-extension-name)
+- [`sl microservice [NAME]`](#sl-microservice-name)
+- [`sl scaffold [NAME]`](#sl-scaffold-name)
+- [`sl update`](#sl-update)
 
 ## `sl autocomplete [SHELL]`
 
@@ -154,4 +157,5 @@ OPTIONS
 ```
 
 _See code: [src/commands/update.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/v3.0.9/src/commands/update.ts)_
+
 <!-- commandsstop -->

--- a/packages/cli/src/generators/microservice/index.ts
+++ b/packages/cli/src/generators/microservice/index.ts
@@ -20,6 +20,7 @@ import {
   getDependencyVersion,
   JSON_SPACING,
 } from '../../utils';
+const chalk = require('chalk'); //NOSONAR
 
 const DATASOURCE_TEMPLATE = join(
   '..',
@@ -67,9 +68,7 @@ const BACK_TO_ROOT = join('..', '..');
 
 const DEFAULT_NAME = 'microservice';
 
-export default class MicroserviceGenerator extends AppGenerator<
-  MicroserviceOptions
-> {
+export default class MicroserviceGenerator extends AppGenerator<MicroserviceOptions> {
   constructor(args: string[], opts: MicroserviceOptions) {
     super(args, opts);
   }
@@ -145,8 +144,8 @@ export default class MicroserviceGenerator extends AppGenerator<
     const type = this.options.facade ? 'facades' : 'services';
     if (!this.shouldExit()) {
       if (type === 'services') {
-        this.projectInfo.baseServiceComponentName = 
-        this._setBaseServiceComponentName();
+        this.projectInfo.baseServiceComponentName =
+          this._setBaseServiceComponentName();
         const baseServiceDSList = this._setDataSourceName();
         this.projectInfo.baseServiceDSList = baseServiceDSList.filter(
           ds => ds.type === 'store',
@@ -212,12 +211,11 @@ export default class MicroserviceGenerator extends AppGenerator<
       scripts['coverage'] = 'nyc npm run test';
       packageJson.scripts = scripts;
       if (this.options.baseService) {
-        packageJson.dependencies[
-          `@sourceloop/${this.options.baseService}`
-        ] = getDependencyVersion(
-          this.projectInfo.dependencies,
-          `@sourceloop/${this.options.baseService}`,
-        );
+        packageJson.dependencies[`@sourceloop/${this.options.baseService}`] =
+          getDependencyVersion(
+            this.projectInfo.dependencies,
+            `@sourceloop/${this.options.baseService}`,
+          );
       }
       fs.writeFileSync(
         packageJsonFile,
@@ -426,6 +424,24 @@ export default class MicroserviceGenerator extends AppGenerator<
   private _includeSourceloopMigrations() {
     const name = this.options.name ?? DEFAULT_NAME;
     if (!this.shouldExit() && this.options.baseService) {
+      if (
+        !this.fs.exists(
+          this.destinationPath(
+            join(
+              'services',
+              name,
+              sourceloopMigrationPath(this.options.baseService),
+            ),
+          ),
+        )
+      ) {
+        this.log(
+          chalk.cyan(
+            `Since migrations does not exist in the base service generating without migrations`,
+          ),
+        );
+        return;
+      }
       this.fs.copy(
         this.destinationPath(
           join(


### PR DESCRIPTION
gh-1053

## Description

When the base service does not have migrations
the user select yes for copy migrations from base service
cli throws an error and does not handle it 
 now will gracefully handle the condition and not throw error .

Fixes #1053

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
