### PR TITLE
fix(cli): can generate multiple local packages using extension comamnd

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,27 +13,30 @@ npm install @sourceloop/cli
 ## Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g @sourceloop/cli
 $ sl COMMAND
 running command...
 $ sl (-v|--version|version)
-@sourceloop/cli/3.0.4 linux-x64 node-v16.13.0
+@sourceloop/cli/3.0.1 linux-x64 node-v16.14.2
 $ sl --help [COMMAND]
 USAGE
   $ sl COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 ## Commands
 
 <!-- commands -->
-* [`sl autocomplete [SHELL]`](#sl-autocomplete-shell)
-* [`sl extension [NAME]`](#sl-extension-name)
-* [`sl microservice [NAME]`](#sl-microservice-name)
-* [`sl scaffold [NAME]`](#sl-scaffold-name)
-* [`sl update`](#sl-update)
+
+- [`sl autocomplete [SHELL]`](#sl-autocomplete-shell)
+- [`sl extension [NAME]`](#sl-extension-name)
+- [`sl microservice [NAME]`](#sl-microservice-name)
+- [`sl scaffold [NAME]`](#sl-scaffold-name)
+- [`sl update`](#sl-update)
 
 ## `sl autocomplete [SHELL]`
 
@@ -154,4 +157,5 @@ OPTIONS
 ```
 
 _See code: [src/commands/update.ts](https://github.com/sourcefuse/loopback4-microservice-catalog/blob/v3.0.4/src/commands/update.ts)_
+
 <!-- commandsstop -->

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -20104,7 +20104,7 @@
         "binaryextensions": "^4.16.0",
         "commondir": "^1.0.1",
         "deep-extend": "^0.6.0",
-        "ejs": "^3.1.7",
+        "ejs": "^3.1.8",
         "globby": "^11.1.0",
         "isbinaryfile": "^4.0.8",
         "minimatch": "^3.1.2",


### PR DESCRIPTION
gh-1074

## Description

when a package is generated using sl extension command 
the name of the package will be one passed in options or in prompts
user can generate multiple packages no need to override the old one

Fixes #1074

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
