### PR TITLE
refactor(typedoc): resolve sonar code smells

### DIFF
--- a/.czferc.js
+++ b/.czferc.js
@@ -48,6 +48,8 @@ const scopes = [
   {name: 'ocr-parser'},
   {name: 'user-tenant-service'},
   {name: 'all-services'},
+  {name: 'typedoc'},
+  {name: 'mkdocs'},
 ];
 
 /**


### PR DESCRIPTION
## What's changed?
- File: `export-typedocs.ts`
  - removed redundant console statements
  - thrown errors where necessary
- File: `.czferc.js`
  - added new commitzen scope called `typedoc` and `mkdocs` for related code changes in the repo

Fixes #1217