### PR TITLE
fix(chore): setting install-links to false to avoid installing the file protocol dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
       - run: node --version
       - run: npm --version
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 16
 
       - name: lerna-bootstrap
         uses: m19c/action-lerna@1.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - run: node --version
+      - run: npm --version
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: 16
 
       - name: lerna-bootstrap
         uses: m19c/action-lerna@1.0.0

--- a/lerna.json
+++ b/lerna.json
@@ -41,7 +41,8 @@
         "@sourceloop/example-socketio",
         "@sourceloop/oauth-example-api",
         "@sourceloop/oauth-example-ui"
-      ]
+      ],
+      "npmClientArgs": ["--loglevel", "verbose", "--no-install-links"]
     },
     "version": {
       "conventionalCommits": true,


### PR DESCRIPTION
## Description

Restricting the node version in CI pipeline to 16.14.2
setting install-links to false to avoid installing the file protocol dependencies.

Fixes #1279 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
