### PR TITLE
fix(cli): use node's fs to verify if a folder exists instead of yeoman's fs

### DIFF
--- a/packages/cli/src/generators/microservice/index.ts
+++ b/packages/cli/src/generators/microservice/index.ts
@@ -425,7 +425,7 @@ export default class MicroserviceGenerator extends AppGenerator<MicroserviceOpti
     const name = this.options.name ?? DEFAULT_NAME;
     if (!this.shouldExit() && this.options.baseService) {
       if (
-        !this.fs.exists(
+        !fs.existsSync(
           this.destinationPath(
             join(
               'services',


### PR DESCRIPTION

## Description

sl microservice was failing to generate base migrations, when the "Include base microservice migrations" is yes, cause yoeman's fs.exists function doesn't work to check if a directory exists

Fixes # (issue)
GH-1358

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
