### PR TITLE
feat(core): prevent cross tenant operation across a…

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -206,7 +206,9 @@ constructor(options: ApplicationConfig = {}) {
     });
 ```
 
-# tenant-guard
+# tenant-utilities
+
+## tenant-guard
 
 A Tenant Guard mixin component that prevents cross db operations through a Loopback repository.
 
@@ -214,17 +216,17 @@ A Tenant Guard mixin component that prevents cross db operations through a Loopb
 
 ## Usage
 
-Configure and load TenantGuardComponent in the application constructor
+Configure and load TenantUtilitiesComponent in the application constructor
 as shown below.
 
 ```ts
-import {TenantGuardComponent} from '@sourceloop/core';
+import {TenantUtilitiesComponent} from '@sourceloop/core';
 // ...
 export class MyApplication extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
 ) {
   constructor(options: ApplicationConfig = {}) {
-    this.component(TenantGuardComponent);
+    this.component(TenantUtilitiesComponent);
     // ...
   }
   // ...
@@ -243,11 +245,8 @@ export class TestModelRepository extends TenantGuardMixin(
     TestModelRelations
   >,
 ) {
-  constructor(
-    @inject('datasources.db') dataSource: DbDataSource,
-    @service(TenantGuardService)
-    public readonly tenantGuard: ITenantGuard<TestModel, string>,
-  ) {
+  tenantGuardService: ITenantGuard<TestModel, string | undefined>;
+  constructor(@inject('datasources.db') dataSource: DbDataSource) {
     super(TestModel, dataSource);
   }
 }
@@ -280,10 +279,10 @@ The `TenantGuardMixin` uses a service of the type `ITenantGuard` to perform the 
 
 #### With Decorator
 
-The decorator uses a binding on key `TenantGuardBindings.GuardService` with the type `ITenantGuard`. It uses a default implementation provided in (`TenantGuardService`)[/src/components/tenant-guard/services/tenant-guard.service.ts], to override this, implement a class from scratch or extending this class, and the binding that class to the `TenantGuardBindings.GuardService` in your `application.ts`-
+The decorator uses a binding on key `TenantUtilitiesBindings.GuardService` with the type `ITenantGuard`. It uses a default implementation provided in (`TenantGuardService`)[/src/components/tenant-utilities/services/tenant-guard.service.ts], to override this, implement a class from scratch or extending this class, and the binding that class to the `TenantUtilitiesBindings.GuardService` in your `application.ts`-
 
 ```ts
-this.bind(TenantGuardBindings.GuardService).toClass(TenantGuardService);
+this.bind(TenantUtilitiesBindings.GuardService).toClass(TenantGuardService);
 ```
 
 ### Decorators

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -206,6 +206,86 @@ constructor(options: ApplicationConfig = {}) {
     });
 ```
 
+# tenant-guard
+
+A Tenant Guard mixin component that prevents cross db operations through a Loopback repository.
+
+[![LoopBack](<https://github.com/loopbackio/loopback-next/raw/master/docs/site/imgs/branding/Powered-by-LoopBack-Badge-(blue)-@2x.png>)](http://loopback.io/)
+
+## Usage
+
+Configure and load TenantGuardComponent in the application constructor
+as shown below.
+
+```ts
+import {TenantGuardComponent} from '@sourceloop/core';
+// ...
+export class MyApplication extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    this.component(TenantGuardComponent);
+    // ...
+  }
+  // ...
+}
+```
+
+### With Mixin
+
+Add the `TenantGuardMixin` mixin to a repository which should not have cross DB operations and provide and service following the `ITenantGuard` with the name `tenantGuardService`-
+
+```ts
+export class TestModelRepository extends TenantGuardMixin(
+  DefaultCrudRepository<
+    TestModel,
+    typeof TestModelRelations.prototype.id,
+    TestModelRelations
+  >,
+) {
+  constructor(
+    @inject('datasources.db') dataSource: DbDataSource,
+    @service(TenantGuardService)
+    public readonly tenantGuard: ITenantGuard<TestModel, string>,
+  ) {
+    super(TestModel, dataSource);
+  }
+}
+```
+
+### With Decorator
+
+Add the `tenantGuard()` decorator to your repository class -
+
+```ts
+import {tenantGuard} from '@sourceloop/core';
+// ...
+@tenantGuard()
+export class TestWithoutGuardRepo extends DefaultTransactionalRepository<
+  TestModel,
+  string,
+  {}
+> {
+  constructor(@inject('datasources.db') dataSource: juggler.DataSource) {
+    super(TestModel, dataSource);
+  }
+}
+```
+
+### Service
+
+#### With Mixin
+
+The `TenantGuardMixin` uses a service of the type `ITenantGuard` to perform the modification of requests on a tenant, If you want to modify the modification logic, you can bind any service following this interface in your repo to a property with name `tenantGuardService`.
+
+#### With Decorator
+
+The decorator uses a binding on key `TenantGuardBindings.GuardService` with the type `ITenantGuard`. It uses a default implementation provided in (`TenantGuardService`)[/src/components/tenant-guard/services/tenant-guard.service.ts], to override this, implement a class from scratch or extending this class, and the binding that class to the `TenantGuardBindings.GuardService` in your `application.ts`-
+
+```ts
+this.bind(TenantGuardBindings.GuardService).toClass(TenantGuardService);
+```
+
 ### Decorators
 
 ## Overview

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "eslint": "lb-eslint --report-unused-disable-directives .",
     "eslint:fix": "npm run eslint -- --fix",
     "pretest": "npm run build",
-    "test": "echo \"No tests !\"",
+    "test": "lb-mocha --allow-console-logs \"dist/__tests__\"",
     "posttest": "npm run lint",
     "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
     "clean": "lb-clean dist *.tsbuildinfo .eslintcache"

--- a/packages/core/src/__tests__/const.ts
+++ b/packages/core/src/__tests__/const.ts
@@ -1,0 +1,46 @@
+import {TenantType} from '../components/tenant-utilities/enums';
+
+export const mockUser1 = {
+  tenantId: 'test',
+  permissions: [],
+  role: 'test',
+  authClientId: 0,
+  firstName: 'test2',
+  lastName: 'test',
+  email: 'test',
+  username: 'test',
+};
+
+export const mockUser2 = {
+  tenantId: 'test2',
+  permissions: [],
+  role: 'test',
+  authClientId: 0,
+  firstName: 'test2',
+  lastName: 'test',
+  email: 'test',
+  username: 'test',
+};
+
+export const mockUserWithoutTenantId = {
+  tenantId: '',
+  permissions: [],
+  role: 'test',
+  authClientId: 0,
+  firstName: 'test2',
+  lastName: 'test',
+  email: 'test',
+  username: 'test',
+};
+
+export const mockSuperAdmin = {
+  tenantId: 'super',
+  permissions: ['0'],
+  tenantType: TenantType.MASTER,
+  role: 'test',
+  authClientId: 0,
+  firstName: 'test2',
+  lastName: 'test',
+  email: 'test',
+  username: 'test',
+};

--- a/packages/core/src/__tests__/fixtures/tenant-utilities/application.ts
+++ b/packages/core/src/__tests__/fixtures/tenant-utilities/application.ts
@@ -1,0 +1,32 @@
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {ServiceMixin} from '@loopback/service-proxy';
+import {TestModel, TestRepo} from '.';
+import {TenantUtilitiesComponent} from '../../../components/tenant-utilities/component';
+import {TestWithoutGuardRepo} from './test-without-guard.repository';
+
+export class DummyApp extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+
+    this.repository(TestWithoutGuardRepo);
+    this.repository(TestRepo);
+    this.model(TestModel);
+    this.component(TenantUtilitiesComponent);
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}

--- a/packages/core/src/__tests__/fixtures/tenant-utilities/index.ts
+++ b/packages/core/src/__tests__/fixtures/tenant-utilities/index.ts
@@ -1,0 +1,3 @@
+export * from './application';
+export * from './test.model';
+export * from './test.repository';

--- a/packages/core/src/__tests__/fixtures/tenant-utilities/test-without-guard.repository.ts
+++ b/packages/core/src/__tests__/fixtures/tenant-utilities/test-without-guard.repository.ts
@@ -1,0 +1,15 @@
+import {inject} from '@loopback/core';
+import {DefaultTransactionalRepository, juggler} from '@loopback/repository';
+import {tenantGuard} from '../../../components/tenant-utilities/decorators/tenant-guard.decorator';
+import {TestModel} from './test.model';
+
+@tenantGuard()
+export class TestWithoutGuardRepo extends DefaultTransactionalRepository<
+  TestModel,
+  string,
+  {}
+> {
+  constructor(@inject('datasources.db') dataSource: juggler.DataSource) {
+    super(TestModel, dataSource);
+  }
+}

--- a/packages/core/src/__tests__/fixtures/tenant-utilities/test.model.ts
+++ b/packages/core/src/__tests__/fixtures/tenant-utilities/test.model.ts
@@ -1,0 +1,26 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class TestModel extends Entity {
+  @property({
+    id: true,
+    type: 'string',
+    generated: true,
+  })
+  id: string;
+
+  @property({
+    required: true,
+    type: 'string',
+  })
+  name: string;
+
+  @property({
+    required: true,
+    type: 'string',
+  })
+  tenantId: string;
+  constructor(data?: Partial<TestModel>) {
+    super(data);
+  }
+}

--- a/packages/core/src/__tests__/fixtures/tenant-utilities/test.repository.ts
+++ b/packages/core/src/__tests__/fixtures/tenant-utilities/test.repository.ts
@@ -1,0 +1,21 @@
+import {inject} from '@loopback/core';
+import {DefaultTransactionalRepository, juggler} from '@loopback/repository';
+import {tenantGuard} from '../../../components/tenant-utilities/decorators';
+import {TenantUtilitiesBindings} from '../../../components/tenant-utilities/keys';
+import {ITenantGuard} from '../../../components/tenant-utilities/types';
+import {TestModel} from './test.model';
+
+@tenantGuard()
+export class TestRepo extends DefaultTransactionalRepository<
+  TestModel,
+  string,
+  {}
+> {
+  constructor(
+    @inject('datasources.db') dataSource: juggler.DataSource,
+    @inject(TenantUtilitiesBindings.GuardService)
+    public tenantGuardService?: ITenantGuard<TestModel, string>,
+  ) {
+    super(TestModel, dataSource);
+  }
+}

--- a/packages/core/src/__tests__/integration/tenant-utilities/repo-with-guarded-tenant.decorator.decorator.ts
+++ b/packages/core/src/__tests__/integration/tenant-utilities/repo-with-guarded-tenant.decorator.decorator.ts
@@ -1,0 +1,46 @@
+import {juggler} from '@loopback/repository';
+import {expect, sinon} from '@loopback/testlab';
+import {AuthenticationBindings} from 'loopback4-authentication';
+import {TenantUtilitiesBindings} from '../../../components/tenant-utilities/keys';
+import {TenantGuardService} from '../../../components/tenant-utilities/services';
+import {mockUser1} from '../../const';
+import {DummyApp, TestRepo} from '../../fixtures/tenant-utilities';
+import {TestWithoutGuardRepo} from '../../fixtures/tenant-utilities/test-without-guard.repository';
+
+describe('TenantGuardDecorator', () => {
+  let app: DummyApp;
+  let repo: TestWithoutGuardRepo;
+  beforeEach(async () => {
+    app = new DummyApp();
+    const ds = new juggler.DataSource({
+      name: 'db',
+      connector: 'memory',
+    });
+    app.bind(AuthenticationBindings.CURRENT_USER).to(mockUser1);
+    app.dataSource(ds);
+    await app.boot();
+    await app.start();
+    repo = await app.getRepository(TestWithoutGuardRepo);
+  });
+  afterEach(async () => {
+    await app.stop();
+  });
+
+  it('should be able use existing guard service provided by the componentF', async () => {
+    const result = await repo.create({name: 'test'});
+    expect(result).to.have.property('tenantId', mockUser1.tenantId);
+  });
+
+  it('should be able to use a new guard service bound in the context', async () => {
+    const stub = sinon.createStubInstance(TenantGuardService);
+    stub.skipTenantGuard.resolves(false);
+    const mockPayload = {name: 'test', tenantId: 'test'};
+    stub.create.resolves(mockPayload);
+    app.bind(TenantUtilitiesBindings.GuardService).to(stub);
+    const newRepo = await app.get<TestRepo>('repositories.TestRepo');
+    const result = await newRepo.create({name: 'test'});
+    sinon.assert.calledOnce(stub.skipTenantGuard);
+    expect(result).to.have.property('tenantId', mockPayload.tenantId);
+    expect(result).to.have.property('name', mockPayload.name);
+  });
+});

--- a/packages/core/src/__tests__/integration/tenant-utilities/tenant-guard.mixin.integration.ts
+++ b/packages/core/src/__tests__/integration/tenant-utilities/tenant-guard.mixin.integration.ts
@@ -1,0 +1,1039 @@
+import {
+  DefaultCrudRepository,
+  FilterExcludingWhere,
+  juggler,
+} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
+import {expect} from '@loopback/testlab';
+import {fail} from 'assert';
+import {TenantUtilitiesErrorKeys} from '../../../components/tenant-utilities/error-keys';
+import {TenantGuardMixin} from '../../../components/tenant-utilities/mixins';
+import {TenantGuardService} from '../../../components/tenant-utilities/services';
+import {ITenantGuard} from '../../../components/tenant-utilities/types';
+import {
+  mockSuperAdmin,
+  mockUser1,
+  mockUser2,
+  mockUserWithoutTenantId,
+} from '../../const';
+import {TestModel} from '../../fixtures/tenant-utilities/test.model';
+import {TestRepo} from '../../fixtures/tenant-utilities/test.repository';
+const NOT_FOUND_CODE = 'ENTITY_NOT_FOUND';
+describe('TenantGuardMixin', () => {
+  let ds: juggler.DataSource;
+  let tenantGuard1: ITenantGuard<TestModel, string>;
+  let tenantGuard2: ITenantGuard<TestModel, string>;
+  let tenantGuardWithoutTenant: ITenantGuard<TestModel, string>;
+  let tenantGuardForSuperAdmin: ITenantGuard<TestModel, string>;
+  let repo1: TestRepo;
+  let repo2: TestRepo;
+  let superAdminRepo: TestRepo;
+  let repoWithoutTenant: TestRepo;
+  let rawRepo: DefaultCrudRepository<TestModel, string>;
+  beforeEach(async () => {
+    await init();
+  });
+  it('should work with default crud repository', async () => {
+    class TestDefaultRepo extends TenantGuardMixin(
+      DefaultCrudRepository<TestModel, string, {}>,
+    ) {
+      tenantGuardService: ITenantGuard<TestModel, string>;
+    }
+
+    const instance = new TestDefaultRepo(TestModel, ds);
+    expect(instance).to.have.property('create');
+    expect(instance).to.have.property('createAll');
+    expect(instance).to.have.property('save');
+    expect(instance).to.have.property('update');
+    expect(instance).to.have.property('updateAll');
+    expect(instance).to.have.property('updateById');
+    expect(instance).to.have.property('replaceById');
+    expect(instance).to.have.property('delete');
+    expect(instance).to.have.property('deleteAll');
+  });
+  it('should work with default transactional crud repository', async () => {
+    const instance = new TestRepo(ds, tenantGuard1);
+    expect(instance).to.have.property('create');
+    expect(instance).to.have.property('createAll');
+    expect(instance).to.have.property('save');
+    expect(instance).to.have.property('update');
+    expect(instance).to.have.property('updateAll');
+    expect(instance).to.have.property('updateById');
+    expect(instance).to.have.property('replaceById');
+    expect(instance).to.have.property('delete');
+    expect(instance).to.have.property('deleteAll');
+    expect(instance).to.have.property('beginTransaction');
+  });
+
+  describe('findById', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.findById('test');
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('it should throw not found error if trying to find record of different tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      try {
+        await repo2.findById(result.id);
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('it should return record if tenant id of user matches', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      const result2 = await repo1.findById(result.id);
+      expect(result2).to.have.property('id', result.id);
+    });
+    it('it should override tenantId even if present in filter', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      await repo2.create({
+        name: 'test',
+      });
+      try {
+        await repo1.findById(result.id, {
+          fields: ['name'],
+          where: {
+            tenantId: mockUser2.tenantId,
+          },
+        } as FilterExcludingWhere<TestModel>);
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('it should find any tenant record for super admin', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      const result2 = await superAdminRepo.findById(result.id);
+      expect(result2).to.have.property('id', result.id);
+    });
+  });
+
+  describe('find', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.find();
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('it should return records if tenant id of user matches', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      await repo1.create({
+        name: 'test',
+      });
+      await repo2.create({
+        name: 'test',
+      });
+      const result = await repo1.find();
+      expect(result).to.have.length(2);
+    });
+    it('it should return records if tenant id of user matches and filter is passed', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      await repo1.create({
+        name: 'test1',
+      });
+      const result = await repo1.find({
+        where: {
+          name: 'test',
+        },
+      });
+      expect(result).to.have.length(1);
+      expect(result[0]).to.have.property('name', 'test');
+    });
+    it('it should override tenantId even if present in filter', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      await repo2.create({
+        name: 'test',
+      });
+      const result = await repo1.find({
+        where: {
+          tenantId: mockUser2.tenantId,
+        },
+      } as FilterExcludingWhere<TestModel>);
+      expect(result).to.have.length(0);
+    });
+    it('it should find any tenant record for super admin', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      const [result2] = await superAdminRepo.find({where: {id: result.id}});
+      expect(result2).to.have.property('id', result.id);
+    });
+  });
+
+  describe('findOne', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.findOne();
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('it should return record if tenant id of user matches with filter', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      await repo1.create({
+        name: 'test1',
+      });
+      await repo2.create({
+        name: 'test',
+      });
+      const result = await repo1.findOne({
+        where: {
+          name: 'test',
+        },
+      });
+      expect(result).to.have.property('name', 'test');
+      expect(result).to.have.property('tenantId', mockUser1.tenantId);
+    });
+    it('it should return record if tenant id of user matches and filter is passed', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      await repo1.create({
+        name: 'test',
+      });
+      const result = await repo1.findOne({
+        where: {
+          name: 'test',
+        },
+      });
+      expect(result).to.have.property('name', 'test');
+      expect(result).to.have.property('tenantId', mockUser1.tenantId);
+    });
+    it('it should override tenantId even if present in filter', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      await repo2.create({
+        name: 'test',
+      });
+      const result = await repo1.findOne({
+        where: {
+          name: 'test',
+          tenantId: mockUser2.tenantId,
+        },
+      } as FilterExcludingWhere<TestModel>);
+      expect(result).to.be.null();
+    });
+    it('it should find any tenant record for super admin', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      const result2 = await superAdminRepo.findOne({where: {id: result.id}});
+      expect(result2).to.have.property('id', result.id);
+    });
+  });
+
+  describe('count', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.count();
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('it should return count if tenant id of user matches', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      await repo1.create({
+        name: 'test',
+      });
+      await repo2.create({
+        name: 'test',
+      });
+      const result = await repo1.count();
+      expect(result.count).to.equal(2);
+    });
+    it('it should return count if tenant id of user matches and filter is passed', async () => {
+      await repo1.create({
+        name: 'test1',
+      });
+      await repo1.create({
+        name: 'test',
+      });
+      await repo2.create({
+        name: 'test2',
+      });
+      const result = await repo1.count({
+        name: 'test',
+      });
+      expect(result.count).to.equal(1);
+    });
+    it('it should give count for any tenant record for super admin', async () => {
+      await repo1.create({
+        name: 'test',
+      });
+      const result2 = await superAdminRepo.count({name: 'test'});
+      expect(result2.count).to.equal(1);
+    });
+  });
+
+  describe('exists', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.exists('1');
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('it should return true if tenant id of user matches and record exists', async () => {
+      const result = await repo1.create({
+        name: 'test1',
+      });
+      const output = await repo1.exists(result.id);
+      expect(output).to.be.true();
+    });
+    it('it should return false if tenant id of user matches and record does not exists', async () => {
+      const result = await repo1.create({
+        name: 'test1',
+      });
+      const output = await repo1.exists(result.id + 1);
+      expect(output).to.be.false();
+    });
+    it('it should return false if trying to find record of different tenant', async () => {
+      const result = await repo1.create({
+        name: 'test1',
+      });
+      const output = await repo2.exists(result.id);
+      expect(output).to.be.false();
+    });
+    it('it should check existance for any tenant record for super admin', async () => {
+      const result1 = await repo1.create({
+        name: 'test',
+      });
+      const result2 = await superAdminRepo.exists(result1.id);
+      expect(result2).to.be.true();
+    });
+  });
+
+  describe('create', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should add tenant id on create call if not present', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      expect(result).to.have.property('tenantId', 'test');
+      expect(result.tenantId).to.equal(mockUser1.tenantId);
+    });
+    it('it should throw error if tenant id in create call data does not match user tenant', async () => {
+      try {
+        await repo1.create({
+          name: 'test',
+          tenantId: 'newid',
+        });
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Forbidden);
+        expect(e.message).to.equal(
+          TenantUtilitiesErrorKeys.TenantIdDoesNotMatch,
+        );
+      }
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.create({
+          name: 'test1',
+        });
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('it should create any tenant record for super admin', async () => {
+      const result = await superAdminRepo.create({
+        name: 'test',
+        tenantId: 'newId',
+      });
+      expect(result).to.have.property('id');
+      expect(result).to.have.property('name', 'test');
+      expect(result).to.have.property('tenantId', 'newId');
+    });
+  });
+  describe('createAll', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should add tenant id on createAll call if not present', async () => {
+      const result = await repo1.createAll([
+        {
+          name: 'test1',
+        },
+        {
+          name: 'test2',
+        },
+      ]);
+      expect(result).to.have.length(2);
+      expect(result[0]).to.have.property('tenantId').equal(mockUser1.tenantId);
+      expect(result[1]).to.have.property('tenantId').equal(mockUser1.tenantId);
+    });
+    it('it should throw error if tenant id in createAll call data does not match user tenant', async () => {
+      const wrongId = 'randomId';
+      try {
+        await repo1.createAll([
+          {
+            name: 'test1',
+            tenantId: mockUser1.tenantId,
+          },
+          {
+            name: 'test2',
+            tenantId: wrongId,
+          },
+        ]);
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Forbidden);
+        expect(e.message).to.equal(
+          `${TenantUtilitiesErrorKeys.TenantIdDoesNotMatch}: ${wrongId}`,
+        );
+      }
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.createAll([
+          {
+            name: 'test1',
+          },
+          {
+            name: 'test2',
+          },
+        ]);
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('it should create any tenant record for super admin', async () => {
+      const results = await superAdminRepo.createAll([
+        {
+          name: 'test1',
+          tenantId: 'newId1',
+        },
+        {
+          name: 'test2',
+          tenantId: 'newId2',
+        },
+      ]);
+      expect(results).to.have.length(2);
+      expect(results[0]).to.have.property('id');
+      expect(results[0]).to.have.property('name', 'test1');
+      expect(results[0]).to.have.property('tenantId', 'newId1');
+      expect(results[1]).to.have.property('id');
+      expect(results[1]).to.have.property('name', 'test2');
+      expect(results[1]).to.have.property('tenantId', 'newId2');
+    });
+  });
+  describe('save', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should add tenant id on save call if not present', async () => {
+      const result = await repo1.save(new TestModel({name: 'test'}));
+      expect(result).to.have.property('tenantId', 'test');
+      expect(result.tenantId).to.equal(mockUser1.tenantId);
+    });
+    it('it should check tenant id on save call if already present in data', async () => {
+      const result = await repo1.save(
+        new TestModel({
+          tenantId: mockUser1.tenantId,
+          name: 'test',
+        }),
+      );
+      expect(result).to.have.property('tenantId', 'test');
+      expect(result.tenantId).to.equal(mockUser1.tenantId);
+    });
+    it('it should check tenant id on save call if already present in db', async () => {
+      const data = await repo1.create({
+        tenantId: mockUser1.tenantId,
+        name: 'test',
+      });
+      const result = await repo1.save(
+        new TestModel({
+          id: data.id,
+          tenantId: mockUser1.tenantId,
+          name: 'testUpdated',
+        }),
+      );
+      expect(result).to.have.property('tenantId', 'test');
+      expect(result.name).to.equal('testUpdated');
+      expect(result.tenantId).to.equal(mockUser1.tenantId);
+    });
+    it('it should throw error if tenant id on save call does not match the users id', async () => {
+      try {
+        await repo1.save(
+          new TestModel({
+            tenantId: mockUser2.tenantId,
+            name: 'testUpdated',
+          }),
+        );
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Forbidden);
+        expect(e.message).to.equal(
+          TenantUtilitiesErrorKeys.TenantIdDoesNotMatch,
+        );
+      }
+    });
+    it('it should throw not found if id on save call belongs to a different tenant than the user', async () => {
+      const data = await repo2.create({
+        name: 'test',
+      });
+      try {
+        await repo1.save(
+          new TestModel({
+            id: data.id,
+            name: 'testUpdated',
+          }),
+        );
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('should save a record of different tenant for super admin', async () => {
+      const result = await superAdminRepo.save(
+        new TestModel({
+          tenantId: 'newId',
+          name: 'test',
+        }),
+      );
+      expect(result).to.have.property('tenantId', 'newId');
+      expect(result.name).to.equal('test');
+      const newResult = await superAdminRepo.save(
+        new TestModel({
+          id: result.id,
+          tenantId: 'newId',
+          name: 'testUpdated',
+        }),
+      );
+      expect(newResult).to.have.property('tenantId', 'newId');
+      expect(newResult.name).to.equal('testUpdated');
+    });
+  });
+  describe('update', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('it should update a record for a tenant even if tenantId not present in payload', async () => {
+      // dummy record
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      await repo1.update(
+        new TestModel({
+          id: result.id,
+          name: 'testUpdated',
+        }),
+      );
+
+      const updated = await rawRepo.findById(result.id);
+      expect(updated).to.have.property('name', 'testUpdated');
+    });
+    it('it should throw not found error if update is on record of some other tenant', async () => {
+      // dummy record
+      const result = await repo2.create({
+        name: 'test',
+      });
+
+      try {
+        await repo1.update(
+          new TestModel({
+            id: result.id,
+            name: 'testUpdated',
+          }),
+        );
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('it should throw forbidden error if update tries to change tenant', async () => {
+      // dummy record
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      try {
+        await repo1.update(
+          new TestModel({
+            id: result.id,
+            name: 'testUpdated',
+            tenantId: mockUser2.tenantId,
+          }),
+        );
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Forbidden);
+      }
+    });
+    it('it should throw error if tenant id of user is not found', async () => {
+      try {
+        await repoWithoutTenant.update(
+          new TestModel({
+            name: 'test1',
+          }),
+        );
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Unauthorized);
+        expect(e.message).to.equal(TenantUtilitiesErrorKeys.TenantIdMissing);
+      }
+    });
+    it('should update a record of different tenant for super admin', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      expect(result).to.have.property('tenantId', mockUser1.tenantId);
+      expect(result.name).to.equal('test');
+      await superAdminRepo.update(
+        new TestModel({
+          id: result.id,
+          name: 'testUpdated',
+        }),
+      );
+      const updated = await rawRepo.findById(result.id);
+      expect(updated).to.have.property('tenantId', mockUser1.tenantId);
+      expect(updated.name).to.equal('testUpdated');
+    });
+  });
+  describe('updateAll', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('should update all records for a tenant even if tenantId not present in payload', async () => {
+      // dummy record
+      const result = await repo1.create({
+        name: 'test2',
+      });
+
+      await repo1.updateAll(
+        {
+          name: 'testUpdated',
+        },
+        {
+          id: result.id,
+        },
+      );
+
+      const updated = await rawRepo.findById(result.id);
+
+      expect(updated).to.have.property('name', 'testUpdated');
+    });
+
+    it('should not effect records of other tenants', async () => {
+      const resultOfDifferentTenant = await repo2.create({
+        name: 'test1',
+      });
+
+      // dummy record
+      const result = await repo1.create({
+        name: 'test2',
+      });
+
+      await repo1.updateAll({
+        name: 'testUpdated',
+      });
+
+      const updated = await rawRepo.findById(result.id);
+      const differentTenantRecord = await rawRepo.findById(
+        resultOfDifferentTenant.id,
+      );
+
+      expect(updated).to.have.property('name', 'testUpdated');
+      expect(differentTenantRecord).to.have.property('name', 'test1');
+    });
+
+    it('should throw when update to tenantId does not match users tenantId', async () => {
+      // dummy record
+      await repo1.create({
+        name: 'test2',
+      });
+
+      try {
+        await repo1.updateAll({
+          name: 'testUpdated',
+          tenantId: mockUser2.tenantId,
+        });
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Forbidden);
+      }
+    });
+    it('should allow updates to records of different tenant for super admin', async () => {
+      const result1 = await repo1.create({
+        name: 'test1',
+      });
+      const result2 = await repo2.create({
+        name: 'test2',
+      });
+      await superAdminRepo.updateAll(
+        {
+          name: 'testUpdated',
+        },
+        {
+          id: {
+            inq: [result1.id, result2.id],
+          },
+        },
+      );
+      const updated1 = await rawRepo.findById(result1.id);
+      const updated2 = await rawRepo.findById(result2.id);
+      expect(updated1).to.have.property('name', 'testUpdated');
+      expect(updated2).to.have.property('name', 'testUpdated');
+    });
+  });
+  describe('updateById', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('should update a record for a tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      await repo1.updateById(result.id, {
+        id: result.id,
+        name: 'testUpdated',
+      });
+
+      const updated = await rawRepo.findById(result.id);
+      expect(updated).to.have.property('name', 'testUpdated');
+    });
+    it('should throw not found for update on a record of a different tenant', async () => {
+      const result = await repo2.create({
+        name: 'test',
+      });
+
+      try {
+        await repo1.updateById(result.id, {
+          id: result.id,
+          name: 'testUpdated',
+        });
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('should throw forbidden if trying to update tenantId to one not matching users', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      try {
+        await repo1.updateById(result.id, {
+          id: result.id,
+          name: 'testUpdated',
+          tenantId: mockUser2.tenantId,
+        });
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Forbidden);
+        expect(e.message).to.equal(
+          TenantUtilitiesErrorKeys.TenantIdDoesNotMatch,
+        );
+      }
+    });
+    it('should allow updates to records of different tenant for super admin', async () => {
+      const record1 = await repo1.create({
+        name: 'test',
+      });
+      await superAdminRepo.updateById(record1.id, {
+        name: 'testUpdated',
+      });
+      const updated1 = await rawRepo.findById(record1.id);
+      expect(updated1).to.have.property('name', 'testUpdated');
+    });
+  });
+  describe('replaceById', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('should replace a record for a tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      await repo1.replaceById(result.id, {
+        name: 'testUpdated',
+        tenantId: mockUser1.tenantId,
+      });
+
+      const updated = await rawRepo.findById(result.id);
+      expect(updated).to.have.property('name', 'testUpdated');
+    });
+    it('should throw not found error if replacing a record of a different tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      try {
+        await repo2.replaceById(result.id, {
+          name: 'testUpdated',
+        });
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('should throw forbidden error if tenantId of record does not match users tenantId', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      try {
+        await repo1.replaceById(result.id, {
+          name: 'testUpdated',
+          tenantId: mockUser2.tenantId,
+        });
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.Forbidden);
+      }
+    });
+    it('should allow updates to records of different tenant for super admin', async () => {
+      const record1 = await repo1.create({
+        name: 'test',
+      });
+      await superAdminRepo.replaceById(record1.id, {
+        name: 'testUpdated',
+        tenantId: mockUser2.tenantId,
+      });
+      const updated1 = await rawRepo.findById(record1.id);
+      expect(updated1).to.have.property('name', 'testUpdated');
+      expect(updated1).to.have.property('tenantId', mockUser2.tenantId);
+    });
+  });
+  describe('delete', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('should delete a record for a tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      await repo1.delete(result);
+
+      try {
+        await rawRepo.findById(result.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+    });
+    it('should throw not found error if deleting a record of a different tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      try {
+        await repo2.delete(
+          new TestModel({
+            id: result.id,
+          }),
+        );
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('should allow delete of records of different tenant for super admin', async () => {
+      const record1 = await repo1.create({
+        name: 'test',
+      });
+      await superAdminRepo.delete(
+        new TestModel({
+          id: record1.id,
+        }),
+      );
+      try {
+        await rawRepo.findById(record1.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+    });
+  });
+  describe('deleteAll', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('should delete all records for a tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      await repo1.deleteAll();
+
+      try {
+        await rawRepo.findById(result.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+    });
+    it('should not affect records of other tenants', async () => {
+      const tenant1Data = await repo1.create({
+        name: 'test',
+      });
+      const tenant2Data = await repo2.create({
+        name: 'test1',
+      });
+      await repo1.deleteAll();
+      try {
+        await rawRepo.findById(tenant1Data.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+      const tenant2DataAfterDelete = await repo2.findById(tenant2Data.id);
+      expect(tenant2DataAfterDelete).to.have.property('name', 'test1');
+    });
+    it('should not affect records of other tenants when using deleteAll with where', async () => {
+      const tenant1Data = await repo1.create({
+        name: 'test',
+      });
+      const tenant2Data = await repo2.create({
+        name: 'test',
+      });
+      await repo1.deleteAll({name: 'test'});
+      try {
+        await rawRepo.findById(tenant1Data.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+      const tenant2DataAfterDelete = await repo2.findById(tenant2Data.id);
+      expect(tenant2DataAfterDelete).to.have.property('name', 'test');
+    });
+    it('should allow delete of records of different tenant for super admin', async () => {
+      const record1 = await repo1.create({
+        name: 'test',
+      });
+      const record2 = await repo2.create({
+        name: 'test',
+      });
+      await superAdminRepo.deleteAll();
+      try {
+        await rawRepo.findById(record1.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+      try {
+        await rawRepo.findById(record2.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+    });
+  });
+  describe('deleteById', () => {
+    beforeEach(async () => {
+      await init();
+    });
+    it('should delete a record for a tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+
+      await repo1.deleteById(result.id);
+
+      try {
+        await rawRepo.findById(result.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+    });
+    it('should throw not found error if deleting a record of a different tenant', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      try {
+        await repo2.deleteById(result.id);
+        fail();
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpErrors.NotFound);
+      }
+    });
+    it('should allow delete of records of different tenant for super admin', async () => {
+      const result = await repo1.create({
+        name: 'test',
+      });
+      await superAdminRepo.deleteById(result.id);
+      try {
+        await rawRepo.findById(result.id);
+        fail();
+      } catch (e) {
+        expect(e.code).to.be.equal(NOT_FOUND_CODE);
+      }
+    });
+  });
+
+  async function init() {
+    ds = new juggler.DataSource({
+      name: 'db',
+      connector: 'memory',
+    });
+    tenantGuard1 = new TenantGuardService(async () => mockUser1);
+    tenantGuard2 = new TenantGuardService(async () => mockUser2);
+    tenantGuardWithoutTenant = new TenantGuardService(
+      async () => mockUserWithoutTenantId,
+    );
+    tenantGuardForSuperAdmin = new TenantGuardService(
+      async () => mockSuperAdmin,
+    );
+    repo1 = new TestRepo(ds, tenantGuard1);
+    repo2 = new TestRepo(ds, tenantGuard2);
+    repoWithoutTenant = new TestRepo(ds, tenantGuardWithoutTenant);
+    superAdminRepo = new TestRepo(ds, tenantGuardForSuperAdmin);
+    rawRepo = new DefaultCrudRepository(TestModel, ds);
+  }
+});

--- a/packages/core/src/__tests__/unit/tenant-utilities/tenant-guard.service.unit.ts
+++ b/packages/core/src/__tests__/unit/tenant-utilities/tenant-guard.service.unit.ts
@@ -1,0 +1,192 @@
+import {Filter, FilterExcludingWhere} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import {TenantGuardService} from '../../../components/tenant-utilities/services';
+import {mockUser1} from '../../const';
+import {TestModel} from '../../fixtures/tenant-utilities';
+
+describe('TenantGuardService', () => {
+  let service: TenantGuardService<TestModel, string>;
+  const mockInstance = new TestModel({
+    id: 'some-id',
+  });
+
+  describe('if filter/where is passed', () => {
+    const mockFilter: Filter<TestModel> = {
+      where: {
+        id: mockInstance.id,
+      },
+      fields: ['name'],
+    };
+    const expectedFilter = {
+      where: {
+        and: [
+          {
+            id: mockInstance.id,
+          },
+          {
+            tenantId: mockUser1.tenantId,
+          },
+        ],
+      },
+      fields: ['name'],
+    };
+    const mockFilterWithoutWhere: FilterExcludingWhere<TestModel> = {
+      fields: ['name'],
+    };
+    const expectedFilterWithoutWhere = {
+      fields: ['name'],
+      where: {
+        tenantId: mockUser1.tenantId,
+        id: mockInstance.id,
+      },
+    };
+    beforeEach(async () => {
+      service = new TenantGuardService<TestModel, string>(
+        async () => mockUser1,
+      );
+    });
+    it('should return a new filter with tenantId for find', async () => {
+      const filter = await service.find(mockFilter);
+      expect(filter).to.have.deepEqual(expectedFilter);
+    });
+    it('should return a new filter with tenantId for findOne', async () => {
+      const filter = await service.findOne(mockFilter);
+      expect(filter).to.deepEqual(expectedFilter);
+    });
+    it('should return a new filter with tenantId for findById', async () => {
+      const filter = await service.findById(
+        mockInstance.id,
+        mockFilterWithoutWhere,
+      );
+      expect(filter).to.have.deepEqual(expectedFilterWithoutWhere);
+    });
+    it('should return a new where with tenantId for count', async () => {
+      const where = await service.count(mockFilter.where);
+      expect(where).to.have.deepEqual(expectedFilter.where);
+    });
+    it('should return a new where with tenantId for exists', async () => {
+      const where = await service.exists(mockInstance.id);
+      expect(where).to.have.deepEqual(expectedFilterWithoutWhere.where);
+    });
+    it('should return a new data with tenantId for create', async () => {
+      const data = await service.create(mockInstance);
+      expect(data).to.have.property('tenantId', mockUser1.tenantId);
+    });
+    it('should return a new data with tenantId for createAll', async () => {
+      const data = await service.createAll([mockInstance]);
+      expect(data[0]).to.have.property('tenantId', mockUser1.tenantId);
+    });
+    it('should return a new data with tenantId for save', async () => {
+      const data = await service.save(mockInstance);
+      expect(data).to.have.property('tenantId', mockUser1.tenantId);
+    });
+    it('should return a new data with tenantId for replaceById', async () => {
+      const newInstance = {
+        ...mockInstance,
+        name: 'new name',
+      };
+      const data = await service.replaceById(mockInstance.id, newInstance);
+      expect(data.where).to.deepEqual(expectedFilterWithoutWhere.where);
+      expect(data.data).to.deepEqual({
+        ...newInstance,
+        tenantId: mockUser1.tenantId,
+      });
+    });
+    it('should return a new data with tenantId for updateById', async () => {
+      const newInstance = {
+        ...mockInstance,
+        name: 'new name',
+      };
+      const data = await service.updateById(mockInstance.id, newInstance);
+      expect(data.where).to.deepEqual(expectedFilterWithoutWhere.where);
+      expect(data.data).to.deepEqual({
+        ...newInstance,
+        tenantId: mockUser1.tenantId,
+      });
+    });
+    it('should return a new data with tenantId for update', async () => {
+      const newInstance = new TestModel({
+        ...mockInstance,
+        name: 'new name',
+      });
+      const data = await service.update(newInstance);
+      expect(data.where).to.deepEqual(expectedFilterWithoutWhere.where);
+      expect(data.data).to.deepEqual(
+        new TestModel({
+          ...newInstance,
+          tenantId: mockUser1.tenantId,
+        }),
+      );
+    });
+    it('should return a new data with tenantId for updateAll', async () => {
+      const newInstance = {
+        ...mockInstance,
+        name: 'new name',
+      };
+      const data = await service.updateAll(newInstance, mockFilter.where);
+      expect(data.where).to.deepEqual(expectedFilter.where);
+      expect(data.data).to.deepEqual({
+        ...newInstance,
+        tenantId: mockUser1.tenantId,
+      });
+    });
+    it('should return a new data with tenantId for deleteById', async () => {
+      const where = await service.deleteById(mockInstance.id);
+      expect(where).to.deepEqual(expectedFilterWithoutWhere.where);
+    });
+    it('should return a new data with tenantId for delete', async () => {
+      const data = await service.delete(mockInstance);
+      expect(data.where).to.deepEqual(expectedFilterWithoutWhere.where);
+      expect(data.entity).to.deepEqual(
+        new TestModel({
+          ...mockInstance,
+          tenantId: mockUser1.tenantId,
+        }),
+      );
+    });
+    it('should return a new data with tenantId for deleteAll', async () => {
+      const where = await service.deleteAll(mockFilter.where);
+      expect(where).to.deepEqual(expectedFilter.where);
+    });
+  });
+  describe('if filter/where is not passed', () => {
+    const expectedFilter = {
+      where: {
+        tenantId: mockUser1.tenantId,
+      },
+    };
+    beforeEach(async () => {
+      service = new TenantGuardService<TestModel, string>(
+        async () => mockUser1,
+      );
+    });
+    it('should return a new filter with tenantId for find', async () => {
+      const filter = await service.find();
+      expect(filter).to.have.deepEqual(expectedFilter);
+    });
+    it('should return a new filter with tenantId for findOne', async () => {
+      const filter = await service.findOne();
+      expect(filter).to.deepEqual(expectedFilter);
+    });
+    it('should return a new where with tenantId for count', async () => {
+      const where = await service.count();
+      expect(where).to.have.deepEqual(expectedFilter.where);
+    });
+    it('should return a new data with tenantId for updateAll', async () => {
+      const newInstance = {
+        ...mockInstance,
+        name: 'new name',
+      };
+      const data = await service.updateAll(newInstance);
+      expect(data.where).to.deepEqual(expectedFilter.where);
+      expect(data.data).to.deepEqual({
+        ...newInstance,
+        tenantId: mockUser1.tenantId,
+      });
+    });
+    it('should return a new data with tenantId for deleteAll', async () => {
+      const where = await service.deleteAll();
+      expect(where).to.deepEqual(expectedFilter.where);
+    });
+  });
+});

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -5,3 +5,4 @@
 export * from './bearer-verifier';
 export * from './logger-extension';
 export * from './swagger-authentication';
+export * from './tenant-utilities';

--- a/packages/core/src/components/tenant-utilities/component.ts
+++ b/packages/core/src/components/tenant-utilities/component.ts
@@ -1,0 +1,28 @@
+import {
+  Application,
+  Component,
+  config,
+  ContextTags,
+  CoreBindings,
+  inject,
+  injectable,
+} from '@loopback/core';
+import {LoggerExtensionComponent} from '../logger-extension';
+import {TenantUtilitiesBindings} from './keys';
+import {TenantGuardService} from './services/tenant-guard.service';
+import {ITenantUtilitiesOptions} from './types';
+
+@injectable({
+  tags: {[ContextTags.KEY]: TenantUtilitiesBindings.Component},
+})
+export class TenantUtilitiesComponent implements Component {
+  constructor(
+    @inject(CoreBindings.APPLICATION_INSTANCE)
+    app: Application,
+    @config({optional: true})
+    configuration?: ITenantUtilitiesOptions,
+  ) {
+    app.component(LoggerExtensionComponent);
+    app.bind(TenantUtilitiesBindings.GuardService).toClass(TenantGuardService);
+  }
+}

--- a/packages/core/src/components/tenant-utilities/decorators/index.ts
+++ b/packages/core/src/components/tenant-utilities/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from './tenant-guard.decorator';

--- a/packages/core/src/components/tenant-utilities/decorators/tenant-guard.decorator.ts
+++ b/packages/core/src/components/tenant-utilities/decorators/tenant-guard.decorator.ts
@@ -1,0 +1,29 @@
+import {DefaultCrudRepository} from '@loopback/repository';
+import {AbstractConstructor} from '../../../mixins/types';
+import {TenantGuardMixin} from '../mixins';
+import {EntityWithTenantId, ITenantGuard} from '../types';
+
+/**
+ * This function returns a class decorator that adds a tenant guard mixin
+ * to the given repository class.
+ *
+ * @param constructor - The repository class to decorate
+ */
+export function tenantGuard() {
+  return <
+    M extends EntityWithTenantId,
+    ID,
+    Relations extends object,
+    S extends AbstractConstructor<DefaultCrudRepository<M, ID, Relations>>,
+  >(
+    constructor: S &
+      AbstractConstructor<DefaultCrudRepository<M, ID, Relations>>,
+  ) => {
+    class GuardedRepo extends TenantGuardMixin(constructor) {
+      public tenantGuardService: ITenantGuard<M, ID>;
+    }
+    // This code is used to set the name of the GuardedRepo class back to the original name
+    Object.defineProperty(GuardedRepo, 'name', {value: constructor.name});
+    return GuardedRepo as typeof constructor;
+  };
+}

--- a/packages/core/src/components/tenant-utilities/enums.ts
+++ b/packages/core/src/components/tenant-utilities/enums.ts
@@ -1,0 +1,4 @@
+export enum TenantType {
+  MASTER = 'master',
+  DEFAULT = 'default',
+}

--- a/packages/core/src/components/tenant-utilities/error-keys.ts
+++ b/packages/core/src/components/tenant-utilities/error-keys.ts
@@ -1,0 +1,4 @@
+export enum TenantUtilitiesErrorKeys {
+  TenantIdMissing = 'Missing Tenant Id',
+  TenantIdDoesNotMatch = 'Tenant Id does not match',
+}

--- a/packages/core/src/components/tenant-utilities/index.ts
+++ b/packages/core/src/components/tenant-utilities/index.ts
@@ -1,0 +1,7 @@
+export * from './component';
+export * from './keys';
+export * from './types';
+export * from './error-keys';
+export * from './services';
+export * from './mixins';
+export * from './decorators';

--- a/packages/core/src/components/tenant-utilities/keys.ts
+++ b/packages/core/src/components/tenant-utilities/keys.ts
@@ -1,0 +1,13 @@
+import {BindingKey} from '@loopback/core';
+import {TenantUtilitiesComponent} from './component';
+import {EntityWithTenantId, ITenantGuard} from './types';
+
+export const TenantUtilitiesNamespace = 'sourceloop.tenant.utilities';
+export namespace TenantUtilitiesBindings {
+  export const Component = BindingKey.create<TenantUtilitiesComponent>(
+    `${TenantUtilitiesNamespace}.TenantUtilitiesComponent`,
+  );
+  export const GuardService = BindingKey.create<
+    ITenantGuard<EntityWithTenantId, string | number>
+  >(`${TenantUtilitiesNamespace}.TenantGuardService`);
+}

--- a/packages/core/src/components/tenant-utilities/mixins/index.ts
+++ b/packages/core/src/components/tenant-utilities/mixins/index.ts
@@ -1,0 +1,1 @@
+export * from './tenant-guard.mixin';

--- a/packages/core/src/components/tenant-utilities/mixins/tenant-guard.mixin.ts
+++ b/packages/core/src/components/tenant-utilities/mixins/tenant-guard.mixin.ts
@@ -1,0 +1,206 @@
+import {
+  AnyObject,
+  Count,
+  DataObject,
+  DefaultCrudRepository,
+  Filter,
+  FilterExcludingWhere,
+  Where,
+} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
+import {
+  AbstractConstructorWithGuard,
+  EntityWithTenantId,
+  ITenantGuard,
+} from '../types';
+
+import {inject} from '@loopback/core';
+import {AbstractConstructor} from '../../../mixins/types';
+import {TenantUtilitiesBindings} from '../keys';
+export function TenantGuardMixin<
+  M extends EntityWithTenantId,
+  ID,
+  Relations extends object,
+  S extends AbstractConstructor<DefaultCrudRepository<M, ID, Relations>>,
+>(
+  superClass: S & AbstractConstructor<DefaultCrudRepository<M, ID, Relations>>,
+) {
+  abstract class GuardedRepo extends superClass {
+    @inject(TenantUtilitiesBindings.GuardService)
+    public tenantGuardService: ITenantGuard<M, ID>;
+
+    async find(
+      filter?: Filter<M>,
+      options?: AnyObject,
+    ): Promise<(M & Relations)[]> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.find(filter, options);
+      }
+      const newFilter = await this.tenantGuardService.find(filter);
+      return super.find(newFilter, options);
+    }
+
+    async findOne(
+      filter?: Filter<M>,
+      options?: AnyObject,
+    ): Promise<(M & Relations) | null> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.findOne(filter, options);
+      }
+      const newFilter = await this.tenantGuardService.findOne(filter);
+      return super.findOne(newFilter, options);
+    }
+
+    async findById(
+      id: ID,
+      filter?: FilterExcludingWhere<M>,
+      options?: AnyObject,
+    ): Promise<M & Relations> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.findById(id, filter, options);
+      }
+      const newFilter = await this.tenantGuardService.findById(id, filter);
+      const record = await super.findOne(newFilter, options);
+      if (record) {
+        return record;
+      }
+      throw new HttpErrors.NotFound();
+    }
+
+    async count(where?: Where<M>, options?: AnyObject): Promise<Count> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.count(where, options);
+      }
+      const newWhere = await this.tenantGuardService.count(where);
+      return super.count(newWhere, options);
+    }
+
+    async exists(id: ID, options?: AnyObject | undefined): Promise<boolean> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.exists(id, options);
+      }
+      const where = await this.tenantGuardService.exists(id);
+      const result = await super.findOne(
+        {
+          where,
+        },
+        options,
+      );
+      return !!result;
+    }
+
+    async create(data: DataObject<M>, options?: AnyObject): Promise<M> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.create(data, options);
+      }
+      const newData = await this.tenantGuardService.create(data);
+      return super.create(newData, options);
+    }
+
+    async createAll(data: DataObject<M>[], options?: AnyObject): Promise<M[]> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.createAll(data, options);
+      }
+      const newData = await this.tenantGuardService.createAll(data);
+      return super.createAll(newData, options);
+    }
+
+    async save(entity: M, options?: AnyObject): Promise<M> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.save(entity, options);
+      }
+      const newEntity = await this.tenantGuardService.save(entity);
+      return super.save(newEntity, options);
+    }
+
+    async update(entity: M, options?: AnyObject): Promise<void> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.update(entity, options);
+      }
+      const args = await this.tenantGuardService.update(entity);
+      const {count} = await super.updateAll(args.data, args.where, options);
+      if (count === 0) {
+        throw new HttpErrors.NotFound();
+      }
+    }
+
+    async updateAll(
+      data: DataObject<M>,
+      where?: Where<M>,
+      options?: AnyObject,
+    ): Promise<Count> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.updateAll(data, where, options);
+      }
+      const newArgs = await this.tenantGuardService.updateAll(data, where);
+      return super.updateAll(newArgs.data, newArgs.where, options);
+    }
+
+    async updateById(
+      id: ID,
+      data: DataObject<M>,
+      options?: AnyObject,
+    ): Promise<void> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.updateById(id, data, options);
+      }
+      const args = await this.tenantGuardService.updateById(id, data);
+      const {count} = await super.updateAll(args.data, args.where, options);
+      if (count === 0) {
+        throw new HttpErrors.NotFound();
+      }
+    }
+
+    async replaceById(
+      id: ID,
+      data: DataObject<M>,
+      options?: AnyObject,
+    ): Promise<void> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.replaceById(id, data, options);
+      }
+      const args = await this.tenantGuardService.replaceById(id, data);
+      const record = await super.findOne(
+        {
+          where: args.where,
+        },
+        options,
+      );
+      if (!record) {
+        throw new HttpErrors.NotFound();
+      }
+      await super.replaceById(id, args.data, options);
+    }
+
+    async delete(entity: M, options?: AnyObject): Promise<void> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.delete(entity, options);
+      }
+      const args = await this.tenantGuardService.delete(entity);
+      const {count} = await super.deleteAll(args.where, options);
+      if (count === 0) {
+        throw new HttpErrors.NotFound();
+      }
+    }
+
+    async deleteAll(where?: Where<M>, options?: AnyObject): Promise<Count> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.deleteAll(where, options);
+      }
+      const newWhere = await this.tenantGuardService.deleteAll(where);
+      return super.deleteAll(newWhere, options);
+    }
+
+    async deleteById(id: ID, options?: AnyObject): Promise<void> {
+      if (await this.tenantGuardService.skipTenantGuard()) {
+        return super.deleteById(id, options);
+      }
+      const newWhere = await this.tenantGuardService.deleteById(id);
+      const {count} = await super.deleteAll(newWhere, options);
+      if (count === 0) {
+        throw new HttpErrors.NotFound();
+      }
+    }
+  }
+  return GuardedRepo as typeof superClass & AbstractConstructorWithGuard<M, ID>;
+}

--- a/packages/core/src/components/tenant-utilities/services/index.ts
+++ b/packages/core/src/components/tenant-utilities/services/index.ts
@@ -1,0 +1,1 @@
+export * from './tenant-guard.service';

--- a/packages/core/src/components/tenant-utilities/services/tenant-guard.service.ts
+++ b/packages/core/src/components/tenant-utilities/services/tenant-guard.service.ts
@@ -1,0 +1,196 @@
+import {BindingScope, Getter, inject, injectable} from '@loopback/core';
+import {
+  AnyObject,
+  DataObject,
+  Filter,
+  FilterExcludingWhere,
+  Where,
+  WhereBuilder,
+} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
+import {AuthenticationBindings} from 'loopback4-authentication';
+
+import {TenantType} from '../enums';
+import {TenantUtilitiesErrorKeys} from '../error-keys';
+import {EntityWithTenantId, ITenantGuard, UserInToken} from '../types';
+
+@injectable({scope: BindingScope.TRANSIENT})
+export class TenantGuardService<T extends EntityWithTenantId, ID>
+  implements ITenantGuard<T, ID>
+{
+  constructor(
+    @inject.getter(AuthenticationBindings.CURRENT_USER)
+    public readonly getCurrentUser: Getter<UserInToken>,
+  ) {}
+
+  async skipTenantGuard(): Promise<boolean> {
+    const user = await this.getCurrentUser();
+    return user.tenantType === TenantType.MASTER;
+  }
+
+  find(filter?: Filter<T>): Promise<Filter<T>> {
+    return this.addTenantToFilter(filter);
+  }
+
+  async findOne(filter?: Filter<T>): Promise<Filter<T>> {
+    return this.addTenantToFilter(filter);
+  }
+
+  async findById(id: ID, filter?: FilterExcludingWhere<T>): Promise<Filter<T>> {
+    return this.addTenantToFilter(filter, id);
+  }
+
+  async count(where?: Where<T>): Promise<Where<T>> {
+    return this.addTenantToWhere(where);
+  }
+
+  async exists(id: ID): Promise<Where<T>> {
+    return this.addTenantToWhere(undefined, id);
+  }
+
+  create(data: DataObject<T>): Promise<DataObject<T>> {
+    return this.addTenantId(data);
+  }
+
+  createAll<R extends DataObject<T> | T>(data: R[]): Promise<R[]> {
+    return this.addTenantIDMultiple(data);
+  }
+
+  save(entity: T): Promise<T> {
+    return this.addTenantId(entity);
+  }
+
+  async replaceById(
+    id: ID,
+    data: DataObject<T>,
+  ): Promise<{data: DataObject<T>; where: Where<T>}> {
+    return this.updateById(id, data);
+  }
+
+  async updateById<R extends DataObject<T> | T>(
+    id: ID,
+    data: R,
+  ): Promise<{data: R; where: Where<T>}> {
+    await this.checkTenantId(data);
+    return this.addTenantToWhere(undefined, id).then(where => ({
+      where,
+      data,
+    }));
+  }
+
+  async update(data: T): Promise<{data: T; where: Where<T>}> {
+    await this.checkTenantId(data);
+    return this.addTenantToWhere(undefined, data.getId()).then(newWhere => ({
+      where: newWhere,
+      data,
+    }));
+  }
+
+  async updateAll(
+    data: DataObject<T>,
+    where?: Where<T>,
+  ): Promise<{data: DataObject<T>; where: Where<T>}> {
+    await this.checkTenantId(data);
+    return this.addTenantToWhere(where).then(newWhere => ({
+      where: newWhere,
+      data,
+    }));
+  }
+
+  deleteById(id: ID): Promise<Where<T>> {
+    return this.addTenantToWhere(undefined, id);
+  }
+
+  async delete(entity: T): Promise<{where: Where<T>; entity: T}> {
+    await this.checkTenantId(entity);
+    return this.addTenantToWhere(undefined, entity.getId()).then(where => ({
+      where,
+      entity,
+    }));
+  }
+
+  async deleteAll(where?: Where<T>): Promise<Where<T>> {
+    return this.addTenantToWhere(where);
+  }
+
+  private async checkTenantId(data: T | DataObject<T>): Promise<void> {
+    const user = await this.getCurrentUser();
+    if (!user.tenantId) {
+      throw new HttpErrors.Unauthorized(
+        TenantUtilitiesErrorKeys.TenantIdMissing,
+      );
+    }
+    if (data.tenantId && data.tenantId !== user.tenantId) {
+      throw new HttpErrors.Forbidden(
+        TenantUtilitiesErrorKeys.TenantIdDoesNotMatch,
+      );
+    }
+  }
+
+  private async addTenantId<S extends DataObject<T> | T>(
+    entity: S,
+  ): Promise<S> {
+    const user = await this.getCurrentUser();
+    await this.checkTenantId(entity);
+    entity.tenantId = user.tenantId;
+    return entity;
+  }
+
+  private async addTenantIDMultiple<R extends DataObject<T> | T>(
+    entities: R[],
+  ): Promise<R[]> {
+    const user = await this.getCurrentUser();
+    const tenantId = user.tenantId;
+    if (tenantId) {
+      entities.forEach(entity => {
+        if (!entity.tenantId) {
+          entity.tenantId = tenantId;
+        } else if (entity.tenantId !== tenantId) {
+          throw new HttpErrors.Forbidden(
+            `${TenantUtilitiesErrorKeys.TenantIdDoesNotMatch}: ${entity.tenantId}`,
+          );
+        } else {
+          // do nothing
+        }
+      });
+      return entities;
+    }
+    throw new HttpErrors.Unauthorized(TenantUtilitiesErrorKeys.TenantIdMissing);
+  }
+
+  private async addTenantToWhere(where?: Where<T>, id?: ID): Promise<Where<T>> {
+    const user = await this.getCurrentUser();
+    if (user.tenantId) {
+      return this.buildWhere(user, where, id);
+    }
+    throw new HttpErrors.Unauthorized(TenantUtilitiesErrorKeys.TenantIdMissing);
+  }
+  private async addTenantToFilter(
+    filter?: Filter<T>,
+    id?: ID,
+  ): Promise<Filter<T>> {
+    const user = await this.getCurrentUser();
+    if (user.tenantId) {
+      return {
+        ...filter,
+        where: this.buildWhere(user, filter?.where, id),
+      };
+    }
+    throw new HttpErrors.Unauthorized(TenantUtilitiesErrorKeys.TenantIdMissing);
+  }
+
+  private buildWhere(user: UserInToken, where?: Where<T>, id?: ID): Where<T> {
+    const whereBuilder = new WhereBuilder<AnyObject>();
+    const extraFilter: AnyObject = {
+      tenantId: user.tenantId,
+    };
+    if (id) {
+      extraFilter.id = id;
+    }
+    if (!where) {
+      return extraFilter as Where<T>;
+    }
+    whereBuilder.and([where, extraFilter].filter(w => !!w));
+    return whereBuilder.build();
+  }
+}

--- a/packages/core/src/components/tenant-utilities/types.ts
+++ b/packages/core/src/components/tenant-utilities/types.ts
@@ -1,0 +1,74 @@
+import {
+  DataObject,
+  Entity,
+  Filter,
+  FilterExcludingWhere,
+  Where,
+} from '@loopback/repository';
+import {AbstractConstructor} from '../../mixins/types';
+import {IAuthUserWithPermissions} from '../bearer-verifier';
+import {TenantType} from './enums';
+
+export interface ITenantUtilitiesOptions {
+  errorKey: string;
+}
+
+export type EntityWithTenantId = Entity & {
+  tenantId: string;
+};
+
+export interface ITenantGuard<T extends Entity, ID> {
+  find(filter?: Filter<T>): Promise<Filter<T>>;
+  findById(id: ID, filter?: FilterExcludingWhere<T>): Promise<Filter<T>>;
+  findOne(filter?: Filter<T>): Promise<Filter<T>>;
+  count(where?: Where<T>): Promise<Where<T>>;
+  exists(id: ID): Promise<Where<T>>;
+  create(data: DataObject<T>): Promise<DataObject<T>>;
+  createAll(data: DataObject<T>[]): Promise<DataObject<T>[]>;
+  save(entity: T): Promise<T>;
+  update(data: T): Promise<{
+    data: T;
+    where: Where<T>;
+  }>;
+  updateAll(
+    data: DataObject<T>,
+    where?: Where<T> | undefined,
+  ): Promise<{
+    data: DataObject<T>;
+    where: Where<T>;
+  }>;
+  updateById(
+    id: ID,
+    data: DataObject<T>,
+  ): Promise<{
+    data: DataObject<T>;
+    where: Where<T>;
+  }>;
+  replaceById(
+    id: ID,
+    data: DataObject<T>,
+  ): Promise<{
+    data: DataObject<T>;
+    where: Where<T>;
+  }>;
+  delete(entity: T): Promise<{
+    where: Where<T>;
+    entity: T;
+  }>;
+  deleteAll(where?: Where<T>): Promise<Where<T>>;
+  deleteById(id: ID): Promise<Where<T>>;
+  skipTenantGuard(): Promise<boolean>;
+}
+
+abstract class WithTenantGuard<T extends EntityWithTenantId, ID> {
+  abstract tenantGuardService: ITenantGuard<T, ID>;
+}
+
+export type AbstractConstructorWithGuard<
+  M extends EntityWithTenantId,
+  ID,
+> = AbstractConstructor<WithTenantGuard<M, ID>>;
+
+export interface UserInToken extends IAuthUserWithPermissions {
+  tenantType?: TenantType;
+}

--- a/packages/core/src/enums/index.ts
+++ b/packages/core/src/enums/index.ts
@@ -2,13 +2,13 @@
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
+export * from './auth-error-keys.enum';
+export * from './auth-provider.enum';
+export * from './config-keys.enum';
 export * from './gender.enum';
+export * from './http-oas.enum';
+export * from './locale-key.enum';
 export * from './roles.enum';
 export * from './status-codes.enum';
-export * from './user-status.enum';
-export * from './config-keys.enum';
-export * from './locale-key.enum';
 export * from './tenant-status.enum';
-export * from './auth-error-keys.enum';
-export * from './http-oas.enum';
-export * from './auth-provider.enum';
+export * from './user-status.enum';

--- a/packages/core/src/keys.ts
+++ b/packages/core/src/keys.ts
@@ -5,8 +5,8 @@
 import {BindingKey} from '@loopback/core';
 import {ExpressRequestHandler} from '@loopback/rest';
 import {BINDING_PREFIX} from './constants';
-import {CoreConfig} from './types';
 import {HttpMethod} from './enums';
+import {CoreConfig} from './types';
 
 export namespace SFCoreBindings {
   export const i18n = BindingKey.create<i18nAPI>(`${BINDING_PREFIX}.i18n`);


### PR DESCRIPTION
## Description

added a mixin tenant that adds the following logic to a loopback repository -
    1 User of one tenant can not perform CRUD on entities of another tenant
    2 his above rule is not applied for a user belong to a master Tenant
added a decorator for applying above mixin with automatic service injection
added a permission for SuperAdmin
added relevant tests

Fixes #1373 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://github.com/shubhamp-sf/sourceloop-tenant-guard-example
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
