### PR TITLE
fix(authentication-service): fix refresh token api creating access token with default tenant id.

### DIFF
--- a/services/authentication-service/src/models/refresh-token.model.ts
+++ b/services/authentication-service/src/models/refresh-token.model.ts
@@ -45,6 +45,11 @@ export class RefreshToken extends Entity {
   })
   pubnubToken?: string;
 
+  @property({
+    type: 'string',
+  })
+  tenantId?: string;
+
   constructor(data?: Partial<RefreshToken>) {
     super(data);
   }

--- a/services/authentication-service/src/modules/auth/models/auth-refresh-token-request.dto.ts
+++ b/services/authentication-service/src/modules/auth/models/auth-refresh-token-request.dto.ts
@@ -12,6 +12,11 @@ export class AuthRefreshTokenRequest extends Model {
   })
   refreshToken: string;
 
+  @property({
+    type: 'string',
+  })
+  tenantId?: string;
+
   constructor(data?: Partial<AuthRefreshTokenRequest>) {
     super(data);
   }

--- a/services/authentication-service/src/providers/jwt-payload.provider.ts
+++ b/services/authentication-service/src/providers/jwt-payload.provider.ts
@@ -44,12 +44,16 @@ export class JwtPayloadProvider implements Provider<JwtPayloadFn> {
   ) {}
 
   value() {
-    return async (authUserData: IAuthUser, authClient: IAuthClient) => {
+    return async (
+      authUserData: IAuthUser,
+      authClient: IAuthClient,
+      tenantId?: string,
+    ) => {
       const user = authUserData as User;
       const userTenant = await this.userTenantRepo.findOne({
         where: {
           userId: (user as User).id, //NOSONAR
-          tenantId: user.defaultTenantId,
+          tenantId: tenantId ?? user.defaultTenantId,
         },
       });
 

--- a/services/authentication-service/src/providers/types.ts
+++ b/services/authentication-service/src/providers/types.ts
@@ -116,6 +116,7 @@ export interface IDeviceInfo {
 export type JwtPayloadFn = (
   user: IAuthUser,
   authClient: IAuthClient,
+  tenantId?: string,
 ) => Promise<object>;
 
 export type ForgotPasswordHandlerFn = (


### PR DESCRIPTION
fixed refresh token API creating access token with default tenant id.

GH-1430

## Description

- Added auth token switch API that will switch access token's tenant id with the required tenant id.

Fixes #1430 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
