### PR TITLE
feat(feature-toggle): add handler service to handle anything specific after feature check

### DIFF
--- a/packages/feature-toggle/README.md
+++ b/packages/feature-toggle/README.md
@@ -7,6 +7,9 @@ A simple loopback-next extension for checking the disabled features. Here a new 
 ## Working and Flow
 
 This extension provides a method level decorator `@featureFlag` that takes the name of the feature that needs to be checked as metadata and verifies if that particular feature is allowed or not. What it expects is that a list of disabled features is saved for the current user of the type `IAuthUserWithDisabledFeat` and compares that with the one passed in the metadata of the decorator.
+The metadata also accepts an optional options that has a handler name parameter. If that handler name is provided that using an extendion point `HandlerService` appropriate handler is called. All the handlers must implement `FeatureHandler` interface.
+
+Only feature check
 
 ```ts
  @featureFlag({featureKey: 'feature_key'})
@@ -16,6 +19,30 @@ If you want to skip the check:
 
 ```ts
 @featureFlag({featureKey: '*'})
+```
+
+Feature Check plus handler call
+
+```ts
+@featureFlag({
+    featureKey: 'feature_key',
+    options: {
+      handler: 'handler_name',
+    },
+  })
+```
+
+This particular handler_name will be matched with the one in handler
+
+```ts
+@injectable(asFeatureHandler)
+export class MyHandler implements FeatureHandler {
+  handlerName = 'handler_name';
+
+  handle(): void {
+    // your logic here
+  }
+}
 ```
 
 A good practice is to keep all feature strings in a separate enum file like this.
@@ -54,6 +81,12 @@ import {FeatureToggleComponent} from '@sourceloop/feature-toggle';
 
 // add Component for FeatureToggle
 this.component(FeatureToggleComponent);
+```
+
+- Adding handlers to the extension points
+
+```ts
+this.add(createBindingFromClass(MyHandler));
 ```
 
 - Then add the decorator over all the APIs where feature needs to be checked. As shown above.

--- a/packages/feature-toggle/src/component.ts
+++ b/packages/feature-toggle/src/component.ts
@@ -8,6 +8,7 @@ import {
   Binding,
   inject,
   CoreBindings,
+  ServiceOrProviderClass,
 } from '@loopback/core';
 import {RestApplication} from '@loopback/rest';
 import {CoreComponent} from '@sourceloop/core';
@@ -17,10 +18,13 @@ import {
   FeatureFlagActionProvider,
   FeatureFlagMetadataProvider,
 } from './providers';
+import {FeatureHandlerService} from './services';
 
 export class FeatureToggleComponent implements Component {
   providers?: ProviderMap;
   bindings?: Binding[];
+  services?: ServiceOrProviderClass[];
+
   constructor(
     @inject(CoreBindings.APPLICATION_INSTANCE)
     private readonly application: RestApplication,
@@ -34,5 +38,6 @@ export class FeatureToggleComponent implements Component {
       [StrategyBindings.FEATURE_FLAG_ACTION.key]: FeatureFlagActionProvider,
       [StrategyBindings.METADATA.key]: FeatureFlagMetadataProvider,
     };
+    this.services = [FeatureHandlerService];
   }
 }

--- a/packages/feature-toggle/src/decorators/feature-flag.decorator.ts
+++ b/packages/feature-toggle/src/decorators/feature-flag.decorator.ts
@@ -11,7 +11,7 @@ export function featureFlag(metadata: FeatureFlagMetadata) {
     FEATURE_FLAG_METADATA_ACCESSOR,
     {
       featureKey: metadata.featureKey,
-      options: metadata.options ?? {},
+      options: metadata.options,
     },
   );
 }

--- a/packages/feature-toggle/src/index.ts
+++ b/packages/feature-toggle/src/index.ts
@@ -7,3 +7,4 @@ export * from './keys';
 export * from './types';
 export * from './decorators';
 export * from './providers';
+export * from './services';

--- a/packages/feature-toggle/src/providers/feature-flag-action.provider.ts
+++ b/packages/feature-toggle/src/providers/feature-flag-action.provider.ts
@@ -2,7 +2,7 @@
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
-import {Getter, inject, Provider} from '@loopback/core';
+import {Getter, inject, Provider, service} from '@loopback/core';
 import {intersection} from 'lodash';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {StrategyBindings} from '../keys';
@@ -12,6 +12,7 @@ import {
   IAuthUserWithDisabledFeat,
 } from '../types';
 import {HttpErrors} from '@loopback/rest';
+import {FeatureHandlerService} from '../services';
 
 export class FeatureFlagActionProvider implements Provider<FeatureFlagFn> {
   constructor(
@@ -19,6 +20,8 @@ export class FeatureFlagActionProvider implements Provider<FeatureFlagFn> {
     private readonly getMetadata: Getter<FeatureFlagMetadata>,
     @inject(AuthenticationBindings.CURRENT_USER)
     private readonly user?: IAuthUserWithDisabledFeat,
+    @service(FeatureHandlerService)
+    private handlerService?: FeatureHandlerService,
   ) {}
   value(): FeatureFlagFn {
     return () => this.action();
@@ -27,20 +30,32 @@ export class FeatureFlagActionProvider implements Provider<FeatureFlagFn> {
   async action(): Promise<boolean> {
     const metadata: FeatureFlagMetadata = await this.getMetadata();
 
-    if (metadata) {
+    if (metadata && this.user) {
       const featureToCheck: string[] = [metadata.featureKey];
       if (featureToCheck.length && featureToCheck[0] === '*') {
         return true; // skip the check and always return true
       }
-      const disabledFeatures = this.user?.disabledFeatures;
+      const disabledFeatures = this.user?.disabledFeatures ?? [];
       if (!disabledFeatures) {
         throw new HttpErrors.InternalServerError(
           'List of disabled features not passed to user',
         );
       }
-      return intersection(featureToCheck, disabledFeatures).length <= 0;
+      const isAllowed =
+        intersection(featureToCheck, disabledFeatures).length <= 0;
+      if (!isAllowed) {
+        return false;
+      } else {
+        // check for handler
+        const handler = metadata.options?.handler;
+
+        if (handler) {
+          return this.handlerService?.handle(metadata, this.user) ?? true;
+        }
+        return true;
+      }
     } else {
-      return false; // need to pass metadata to decorator
+      return true; // not mandatory to apply feature check over all API
     }
   }
 }

--- a/packages/feature-toggle/src/services/feature-handler-service.ts
+++ b/packages/feature-toggle/src/services/feature-handler-service.ts
@@ -1,0 +1,37 @@
+import {Getter, extensionPoint, extensions} from '@loopback/core';
+import {
+  FeatureFlagMetadata,
+  FeatureHandler,
+  HANDLER_EXTENSION_POINT_NAME,
+  IAuthUserWithDisabledFeat,
+} from '../types';
+import {HttpErrors} from '@loopback/rest';
+
+@extensionPoint(HANDLER_EXTENSION_POINT_NAME)
+export class FeatureHandlerService {
+  constructor(
+    @extensions()
+    private getHandlers: Getter<FeatureHandler[]>,
+  ) {}
+
+  async findHandler(handlerName: string): Promise<FeatureHandler | undefined> {
+    const handlers = await this.getHandlers();
+    return handlers.find(h => h.handlerName === handlerName);
+  }
+
+  async handle(
+    featureMetadata: FeatureFlagMetadata,
+    currentUser: IAuthUserWithDisabledFeat,
+  ): Promise<boolean> {
+    if (featureMetadata.options?.handler) {
+      const handler = await this.findHandler(featureMetadata.options?.handler);
+      if (handler) {
+        return handler.handle(featureMetadata, currentUser);
+      } else {
+        throw new HttpErrors.InternalServerError('No Handler Found');
+      }
+    } else {
+      return true;
+    }
+  }
+}

--- a/packages/feature-toggle/src/services/index.ts
+++ b/packages/feature-toggle/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './feature-handler-service';

--- a/packages/feature-toggle/src/types.ts
+++ b/packages/feature-toggle/src/types.ts
@@ -2,12 +2,17 @@
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
+import {BindingTemplate, extensionFor} from '@loopback/core';
 import {IAuthUserWithPermissions} from '@sourceloop/core';
-
 export interface FeatureFlagMetadata {
   featureKey: string;
-  options?: Object;
+  options?: FeatureFlagOptions;
 }
+export type FeatureFlagOptions = {
+  handler: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [property: string]: any; //NOSONAR
+};
 
 export type FeatureInterface = () => Promise<boolean>;
 
@@ -16,3 +21,31 @@ export type FeatureFlagFn = () => Promise<boolean>;
 export interface IAuthUserWithDisabledFeat extends IAuthUserWithPermissions {
   disabledFeatures: string[];
 }
+
+/** Chnages for extension point */
+
+/**
+ * Typically an extension point defines an interface as the contract for
+ * extensions to implement
+ */
+export interface FeatureHandler {
+  handlerName: string;
+  handle(
+    featureMetadata: FeatureFlagMetadata,
+    currentUser: IAuthUserWithDisabledFeat,
+  ): boolean;
+}
+
+/**
+ * Name/id of the handler extension point
+ */
+
+export const HANDLER_EXTENSION_POINT_NAME = 'handlers';
+
+/**
+ * A binding template for handler extensions
+ */
+export const asFeatureHandler: BindingTemplate = binding => {
+  extensionFor(HANDLER_EXTENSION_POINT_NAME)(binding);
+  binding.tag({namespace: 'handlers'});
+};

--- a/services/feature-toggle-service/migrations/20230612141912-update-tables.js
+++ b/services/feature-toggle-service/migrations/20230612141912-update-tables.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20230612141912-update-tables-up.sql',
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20230612141912-update-tables-down.sql',
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1,
+};

--- a/services/feature-toggle-service/migrations/sqls/20230612141912-update-tables-down.sql
+++ b/services/feature-toggle-service/migrations/sqls/20230612141912-update-tables-down.sql
@@ -1,0 +1,29 @@
+ALTER TABLE main.features
+drop column metadata,
+drop column created_by,
+drop column modified_by ,
+drop column created_on ,
+drop column modified_on 
+drop column deleted  ,
+drop column deleted_on ,
+drop column deleted_by;
+
+
+ALTER TABLE main.strategies
+drop column created_by,
+drop column modified_by ,
+drop column created_on ,
+drop column modified_on 
+drop column deleted  ,
+drop column deleted_on ,
+drop column deleted_by;
+
+ALTER TABLE main.feature_toggles
+drop column metadata,
+drop column created_by,
+drop column modified_by ,
+drop column created_on ,
+drop column modified_on 
+drop column deleted  ,
+drop column deleted_on ,
+drop column deleted_by;

--- a/services/feature-toggle-service/migrations/sqls/20230612141912-update-tables-up.sql
+++ b/services/feature-toggle-service/migrations/sqls/20230612141912-update-tables-up.sql
@@ -1,0 +1,29 @@
+/* Replace with your SQL commands */
+
+ALTER TABLE main.features
+ADD metadata text,  
+ADD created_by varchar(100),
+ADD modified_by varchar(100),
+ADD created_on           timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+ADD modified_on          timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+ADD deleted              bool DEFAULT false NOT NULL ,
+ADD deleted_on           timestamptz   ,
+ADD deleted_by           uuid   ;
+
+ALTER TABLE main.strategies
+ADD created_by varchar(100),
+ADD modified_by varchar(100),
+ADD created_on           timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+ADD modified_on          timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+ADD deleted              bool DEFAULT false NOT NULL ,
+ADD deleted_on           timestamptz   ,
+ADD deleted_by           uuid   ;
+
+ALTER TABLE main.feature_toggles
+ADD created_by varchar(100),
+ADD modified_by varchar(100),
+ADD created_on           timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+ADD modified_on          timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL ,
+ADD deleted              bool DEFAULT false NOT NULL ,
+ADD deleted_on           timestamptz   ,
+ADD deleted_by           uuid   ;


### PR DESCRIPTION
MIGRATION CHANGE:
migration-20230612141912- add metadata column

gh-1447

Supersedes: #1448

## Description

Once you check if a feature is allowed to a particular user or not and incase it is allowed one wants to do specific handling on the that particular feature or handle any use case then provide a handler name in the decorator. 
That handler should implement  FeatureHandler interface that has the same name as that mentioned in the decorator.
This handler will be called via an extension point FeatureHandlerService.
This service will return true or false and further decide if a feature is allowed or not.



Fixes #1447

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
