### PR TITLE
feat(workflows): close individual PRs when combined PR is merged

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -96,7 +96,7 @@ jobs:
                 }
                 if (statusOK) {
                   console.log('Adding branch to array: ' + branch);
-                  const prString = '#' + pull['number'] + ' ' + pull['title'];
+                  const prString = 'Closes #' + pull['number'] + ' ' + pull['title'];
                   branchesAndPRStrings.push({ branch, prString });
                   baseBranch = pull['base']['ref'];
                   baseBranchSHA = pull['base']['sha'];


### PR DESCRIPTION
## Description

This PR Adds `Closes` keyword before the successfully merged PR numbers so that GitHub automatically closes the individual PRs when the combined PR is merged.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
