### PR TITLE
fix(core): move `findRoute` to the top in SecureSequence

### DIFF
--- a/packages/core/src/secure-sequence.ts
+++ b/packages/core/src/secure-sequence.ts
@@ -99,6 +99,9 @@ export class SecureSequence implements SequenceHandler {
         Remote Address = ${request.connection.remoteAddress}
         Remote Address (Proxy) = ${request.headers['x-forwarded-for']}`,
       );
+
+      const route = this.findRoute(request);
+
       if (this.rateLimitConfig) {
         await this.rateLimitAction(request, response);
       }
@@ -112,7 +115,6 @@ export class SecureSequence implements SequenceHandler {
 
       const finished = await this.invokeMiddleware(context);
       if (finished) return;
-      const route = this.findRoute(request);
       const args = await this.parseParams(request, route);
 
       if (this.helmetConfig) {


### PR DESCRIPTION
## Description

This PR moves `findRoute` call to the top in `SecureSequence` so that ratelimit action below it can get the values of `CoreBindings.CONTROLLER_CLASS` and method name bindings.

Read #1600

Fixes #1600 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


- [x] Tested in https://github.com/shubhamp-sf/ratelimiter-115

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
