### PR TITLE
feat(core): add ability alter the paths definition received by swagger stats

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,11 +3,14 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 import {IncomingMessage} from 'http';
+import {AnyObject} from 'loopback-datasource-juggler';
 import {SWStats} from 'swagger-stats';
 
 export interface IServiceConfig {
   useCustomSequence: boolean;
 }
+
+export type OASPathDefinition = AnyObject;
 
 export interface CoreConfig {
   name?: string;
@@ -15,6 +18,17 @@ export interface CoreConfig {
   enableObf?: boolean;
   obfPath?: string;
   openapiSpec?: Record<string, unknown>;
+  /**
+   * In order to hide or alter some path from the definition provided by swagger stats, `modifyPathDefinition`
+   * callback can be used. It'll get called for each of the path specified in the `openapiSpec` provided.
+   * @param path The name of the API path.
+   * @param pathDefinition The definition object containing method and other details.
+   * @returns `null` if the path needs to be omitted from the spec else return the `pathDefinition` either in the original form as received in the argument or by modifying it as per the needs.
+   */
+  modifyPathDefinition?: (
+    path: string,
+    pathDefinition: OASPathDefinition,
+  ) => OASPathDefinition | null;
   authentication?: boolean;
   swaggerUsername?: string;
   swaggerPassword?: string;


### PR DESCRIPTION
## Description

This PR introduced a callback in core config named `modifyPathDefinition` in order to allow users to modify or even exclude the path from swagger spec received by swagger-stats middleware.

GH-1613

Fixes #1613 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in and example application: https://github.com/shubhamp-sf/catalog-1613

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [x] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
