### PR TITLE
fix(workflows): use lts of node in release and ci actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,24 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# This workflow contains a single job called "npm_audit"
 jobs:
-  # This workflow contains a single job called "build"
   npm_audit:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: '18.x'
       - run: node --version
       - run: npm --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# This Manually Executable Workflow is for NPM Releases
+
 name: Release [Manual]
 on: workflow_dispatch
 permissions:
@@ -13,9 +15,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_COMMIT_GH_PAT }}
       - name: Setup Node
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Configure CI Git User
         run: |
           git config --global user.name '@shubhamp-sf'


### PR DESCRIPTION
This PR updates the node version in our Release and CI GitHub Action along with other refactoring. 