### PR TITLE
refactor(deps): remove explicit dependency of casbin in core

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -18,7 +18,6 @@
         "@loopback/rest": "^13.1.0",
         "@loopback/rest-explorer": "^6.1.0",
         "@loopback/service-proxy": "^6.1.0",
-        "casbin": "^5.15.0",
         "i18n": "^0.15.1",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
@@ -5943,7 +5942,14 @@
         "@loopback/rest": "^13.1.0"
       }
     },
-    "node_modules/loopback4-authentication/vendor/passport-apple": {},
+    "node_modules/loopback4-authentication/vendor/passport-apple": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "jsonwebtoken": "^9.0.0",
+        "passport-oauth2": "^1.5.0"
+      }
+    },
     "node_modules/loopback4-authorization": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/loopback4-authorization/-/loopback4-authorization-6.1.0.tgz",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,6 @@
     "@loopback/rest": "^13.1.0",
     "@loopback/rest-explorer": "^6.1.0",
     "@loopback/service-proxy": "^6.1.0",
-    "casbin": "^5.15.0",
     "i18n": "^0.15.1",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
This PR removes explicit dependency of casbin in `@sourceloop/core` as it is not used directly. (Read #1658)

Fixes #1658