### PR TITLE
fix(search): add null check for model name in custom search event before set the category

### DIFF
--- a/packages/search/projects/search-lib/src/lib/search/search.component.ts
+++ b/packages/search/projects/search-lib/src/lib/search/search.component.ts
@@ -419,7 +419,10 @@ export class SearchComponent<T extends IReturnType>
         this.searchBoxInput = this.customSearchEvent?.searchValue ?? '';
         this.searchOnCustomEventValueChange(this.searchBoxInput);
       }
-      if (this._isCustomSearchEventChange(changes, 'modelName')) {
+      if (
+        this._isCustomSearchEventChange(changes, 'modelName') &&
+        this.customSearchEvent?.modelName
+      ) {
         this.setCategory(this.customSearchEvent?.modelName);
       }
     }


### PR DESCRIPTION

## Description

add null check for model name in custom search event before setting the category 

![image](https://github.com/sourcefuse/loopback4-microservice-catalog/assets/60221425/8677d98d-c56a-4fd5-89f5-2d99ec20a74e)


Fixes # ([GH-1764](https://github.com/sourcefuse/loopback4-microservice-catalog/issues/1674))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] Code conforms with the style guide

