### PR TITLE
feat(core): add ProxyBuilder component in core

### DIFF
--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -1,2 +1,3 @@
 dist
 *.json
+coverage

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -721,3 +721,7 @@ setupSequence() {
 - You can also use custom sequence instead by providing custom sequence name in the application.
 
 ![sequence](https://loopback.io/pages/en/lb4/imgs/middleware.png)
+
+### ProxyBuilder Component
+
+Read about the `ProxyBuilderComponent` [here](/packages/core/src/components/proxy-builder/README.md).

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -50,6 +50,7 @@
         "@types/request-ip": "^0.0.37",
         "@types/swagger-stats": "^0.95.4",
         "eslint": "^8.44.0",
+        "loopback-connector-rest": "^4.0.3",
         "source-map-support": "^0.5.21",
         "typescript": "~4.9.5"
       },
@@ -57,7 +58,8 @@
         "node": "16 || 17 || 18"
       },
       "peerDependencies": {
-        "@loopback/sequelize": "^0.4.0"
+        "@loopback/sequelize": "^0.4.0",
+        "loopback-connector-rest": "^4.0.3"
       },
       "peerDependenciesMeta": {
         "@loopback/sequelize": {
@@ -2558,6 +2560,24 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -2660,6 +2680,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "dev": true
+    },
     "node_modules/axios": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
@@ -2724,6 +2759,15 @@
       "integrity": "sha512-JnkkL4GUpOvvanH9AZPX38CxhiLsXMBicBY2IAtqiVN8YulGDQybUydWA4W6yAMtw6iShtw+8HEF6cfrTHU+UQ==",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/binary-extensions": {
@@ -3083,6 +3127,12 @@
         "pg": "^8.2.1"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3420,6 +3470,18 @@
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.4.0.tgz",
       "integrity": "sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg=="
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3585,6 +3647,16 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -4132,6 +4204,21 @@
         "jsep": "^0.3.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
     "node_modules/fast-content-type-parse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.0.0.tgz",
@@ -4535,6 +4622,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -4691,6 +4787,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "10.3.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
@@ -4812,6 +4917,51 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "node_modules/has": {
@@ -4957,6 +5107,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
     "node_modules/http-status": {
@@ -5327,6 +5492,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -5619,6 +5790,12 @@
         "xmlcreate": "^2.0.4"
       }
     },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true
+    },
     "node_modules/jsep": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
@@ -5647,6 +5824,12 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
+    },
     "node_modules/json-schema-compare": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
@@ -5664,6 +5847,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "node_modules/json5": {
@@ -5690,6 +5879,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonpath-plus": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
+      "integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
@@ -5703,6 +5901,21 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/just-extend": {
@@ -5873,6 +6086,38 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/loopback-connector-rest": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/loopback-connector-rest/-/loopback-connector-rest-4.0.3.tgz",
+      "integrity": "sha512-qZqd1LgI/1an9eB1ee6uphr4K9fWnhBpduGwdf74dIkeE727yBMWA4opzI/OsnLTy4rhDYRSEwMqd2ecGYKdxw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "jsonpath-plus": "^4.0.0",
+        "lodash": "^4.17.11",
+        "methods": "^1.1.1",
+        "mime": "^2.3.1",
+        "qs": "^6.1.0",
+        "request": "^2.53.0",
+        "strong-globalize": "^6.0.5",
+        "traverse": "^0.6.6"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/loopback-connector-rest/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/loopback-datasource-juggler": {
@@ -7161,6 +7406,15 @@
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
     },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7686,6 +7940,12 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true
+    },
     "node_modules/pg": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.1.tgz",
@@ -8057,6 +8317,12 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -8249,10 +8515,75 @@
         "node": ">=4"
       }
     },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/request-ip": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
       "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/require-at": {
       "version": "1.0.6",
@@ -8952,6 +9283,31 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -9372,6 +9728,19 @@
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "devOptional": true
     },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/traverse": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
@@ -9420,6 +9789,24 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "node_modules/twostep": {
@@ -9659,6 +10046,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "eslint:fix": "npm run eslint -- --fix",
     "pretest": "npm run build",
     "test": "lb-mocha --allow-console-logs \"dist/__tests__\"",
+    "coverage": "lb-nyc --reporter=html npm run test",
     "posttest": "npm run lint",
     "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js && npm run posttest",
     "clean": "lb-clean dist *.tsbuildinfo .eslintcache"
@@ -82,7 +83,8 @@
     "winston": "^3.7.2"
   },
   "peerDependencies": {
-    "@loopback/sequelize": "^0.4.0"
+    "@loopback/sequelize": "^0.4.0",
+    "loopback-connector-rest": "^4.0.3"
   },
   "peerDependenciesMeta": {
     "@loopback/sequelize": {
@@ -104,7 +106,8 @@
     "@types/swagger-stats": "^0.95.4",
     "eslint": "^8.44.0",
     "source-map-support": "^0.5.21",
-    "typescript": "~4.9.5"
+    "typescript": "~4.9.5",
+    "loopback-connector-rest": "^4.0.3"
   },
   "overrides": {
     "body-parser": {

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/child-rest.controller.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/child-rest.controller.ts
@@ -1,0 +1,147 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {Child} from '../models';
+import {ChildRepository} from '../repositories';
+
+export class RestChildController {
+  constructor(
+    @repository(ChildRepository)
+    public childRepo: ChildRepository,
+  ) {}
+
+  @post('/rest-children')
+  @response(200, {
+    description: 'Child model instance',
+    content: {'application/json': {schema: getModelSchemaRef(Child)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Child, {
+            title: 'NewChild',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    child: Omit<Child, 'id'>,
+  ): Promise<Child> {
+    return this.childRepo.create(child);
+  }
+
+  @get('/rest-children/count')
+  @response(200, {
+    description: 'Child model count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async count(@param.where(Child) where?: Where<Child>): Promise<Count> {
+    return this.childRepo.count(where);
+  }
+
+  @get('/rest-children')
+  @response(200, {
+    description: 'Array of Child model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Child, {includeRelations: true}),
+        },
+      },
+    },
+  })
+  async find(@param.filter(Child) filter?: Filter<Child>): Promise<Child[]> {
+    return this.childRepo.find(filter);
+  }
+
+  @patch('/rest-children')
+  @response(200, {
+    description: 'Child PATCH success count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async updateAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Child, {partial: true}),
+        },
+      },
+    })
+    child: Child,
+    @param.where(Child) where?: Where<Child>,
+  ): Promise<Count> {
+    return this.childRepo.updateAll(child, where);
+  }
+
+  @get('/rest-children/{id}')
+  @response(200, {
+    description: 'Child model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Child, {includeRelations: true}),
+      },
+    },
+  })
+  async findById(
+    @param.path.string('id') id: string,
+    @param.filter(Child, {exclude: 'where'})
+    filter?: FilterExcludingWhere<Child>,
+  ): Promise<Child> {
+    return this.childRepo.findById(id, filter);
+  }
+
+  @patch('/rest-children/{id}')
+  @response(204, {
+    description: 'Child PATCH success',
+  })
+  async updateById(
+    @param.path.string('id') id: string,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Child, {partial: true}),
+        },
+      },
+    })
+    child: Child,
+  ): Promise<void> {
+    await this.childRepo.updateById(id, child);
+  }
+
+  @put('/rest-children/{id}')
+  @response(204, {
+    description: 'Child PUT success',
+  })
+  async replaceById(
+    @param.path.string('id') id: string,
+    @requestBody() child: Child,
+  ): Promise<void> {
+    await this.childRepo.replaceById(id, child);
+  }
+
+  @del('/rest-children/{id}')
+  @response(204, {
+    description: 'Child DELETE success',
+  })
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
+    await this.childRepo.deleteById(id);
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/index.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/index.ts
@@ -1,0 +1,4 @@
+export * from './child-rest.controller';
+export * from './parent-rest.controller';
+export * from './parent.controller';
+export * from './parent-config-rest.controller';

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/parent-config-rest.controller.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/parent-config-rest.controller.ts
@@ -1,0 +1,151 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {ParentConfig} from '../models';
+import {ParentConfigRepository} from '../repositories';
+
+export class RestParentConfigController {
+  constructor(
+    @repository(ParentConfigRepository)
+    public parentConfigRepo: ParentConfigRepository,
+  ) {}
+
+  @post('/rest-parent-configs')
+  @response(200, {
+    description: 'ParentConfig model instance',
+    content: {'application/json': {schema: getModelSchemaRef(ParentConfig)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(ParentConfig, {
+            title: 'NewConfig',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    config: Omit<ParentConfig, 'id'>,
+  ): Promise<ParentConfig> {
+    return this.parentConfigRepo.create(config);
+  }
+
+  @get('/rest-parent-configs/count')
+  @response(200, {
+    description: 'ParentConfig model count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async count(
+    @param.where(ParentConfig) where?: Where<ParentConfig>,
+  ): Promise<Count> {
+    return this.parentConfigRepo.count(where);
+  }
+
+  @get('/rest-parent-configs')
+  @response(200, {
+    description: 'Array of ParentConfig model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(ParentConfig, {includeRelations: true}),
+        },
+      },
+    },
+  })
+  async find(
+    @param.filter(ParentConfig) filter?: Filter<ParentConfig>,
+  ): Promise<ParentConfig[]> {
+    return this.parentConfigRepo.find(filter);
+  }
+
+  @patch('/rest-parent-configs')
+  @response(200, {
+    description: 'ParentConfig PATCH success count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async updateAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(ParentConfig, {partial: true}),
+        },
+      },
+    })
+    config: ParentConfig,
+    @param.where(ParentConfig) where?: Where<ParentConfig>,
+  ): Promise<Count> {
+    return this.parentConfigRepo.updateAll(config, where);
+  }
+
+  @get('/rest-parent-configs/{id}')
+  @response(200, {
+    description: 'ParentConfig model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(ParentConfig, {includeRelations: true}),
+      },
+    },
+  })
+  async findById(
+    @param.path.string('id') id: string,
+    @param.filter(ParentConfig, {exclude: 'where'})
+    filter?: FilterExcludingWhere<ParentConfig>,
+  ): Promise<ParentConfig> {
+    return this.parentConfigRepo.findById(id, filter);
+  }
+
+  @patch('/rest-parent-configs/{id}')
+  @response(204, {
+    description: 'ParentConfig PATCH success',
+  })
+  async updateById(
+    @param.path.string('id') id: string,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(ParentConfig, {partial: true}),
+        },
+      },
+    })
+    config: ParentConfig,
+  ): Promise<void> {
+    await this.parentConfigRepo.updateById(id, config);
+  }
+
+  @put('/rest-parent-configs/{id}')
+  @response(204, {
+    description: 'ParentConfig PUT success',
+  })
+  async replaceById(
+    @param.path.string('id') id: string,
+    @requestBody() config: ParentConfig,
+  ): Promise<void> {
+    await this.parentConfigRepo.replaceById(id, config);
+  }
+
+  @del('/rest-parent-configs/{id}')
+  @response(204, {
+    description: 'ParentConfig DELETE success',
+  })
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
+    await this.parentConfigRepo.deleteById(id);
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/parent-rest.controller.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/parent-rest.controller.ts
@@ -1,0 +1,147 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  Where,
+  repository,
+} from '@loopback/repository';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {Parent} from '../models';
+import {ParentRepository} from '../repositories';
+
+export class RestParentController {
+  constructor(
+    @repository(ParentRepository)
+    public parentRepo: ParentRepository,
+  ) {}
+
+  @post('/rest-parents')
+  @response(200, {
+    description: 'Parent model instance',
+    content: {'application/json': {schema: getModelSchemaRef(Parent)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Parent, {
+            title: 'NewParent',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    parent: Omit<Parent, 'id'>,
+  ): Promise<Parent> {
+    return this.parentRepo.create(parent);
+  }
+
+  @get('/rest-parents/count')
+  @response(200, {
+    description: 'Parent model count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async count(@param.where(Parent) where?: Where<Parent>): Promise<Count> {
+    return this.parentRepo.count(where);
+  }
+
+  @get('/rest-parents')
+  @response(200, {
+    description: 'Array of Parent model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Parent, {includeRelations: true}),
+        },
+      },
+    },
+  })
+  async find(@param.filter(Parent) filter?: Filter<Parent>): Promise<Parent[]> {
+    return this.parentRepo.find(filter);
+  }
+
+  @patch('/rest-parents')
+  @response(200, {
+    description: 'Parent PATCH success count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async updateAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Parent, {partial: true}),
+        },
+      },
+    })
+    parent: Parent,
+    @param.where(Parent) where?: Where<Parent>,
+  ): Promise<Count> {
+    return this.parentRepo.updateAll(parent, where);
+  }
+
+  @get('/rest-parents/{id}')
+  @response(200, {
+    description: 'Parent model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Parent, {includeRelations: true}),
+      },
+    },
+  })
+  async findById(
+    @param.path.string('id') id: string,
+    @param.filter(Parent, {exclude: 'where'})
+    filter?: FilterExcludingWhere<Parent>,
+  ): Promise<Parent> {
+    return this.parentRepo.findById(id, filter);
+  }
+
+  @patch('/rest-parents/{id}')
+  @response(204, {
+    description: 'Parent PATCH success',
+  })
+  async updateById(
+    @param.path.string('id') id: string,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Parent, {partial: true}),
+        },
+      },
+    })
+    parent: Parent,
+  ): Promise<void> {
+    await this.parentRepo.updateById(id, parent);
+  }
+
+  @put('/rest-parents/{id}')
+  @response(204, {
+    description: 'Parent PUT success',
+  })
+  async replaceById(
+    @param.path.string('id') id: string,
+    @requestBody() parent: Parent,
+  ): Promise<void> {
+    await this.parentRepo.replaceById(id, parent);
+  }
+
+  @del('/rest-parents/{id}')
+  @response(204, {
+    description: 'Parent DELETE success',
+  })
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
+    await this.parentRepo.deleteById(id);
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/parent.controller.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/controllers/parent.controller.ts
@@ -1,0 +1,149 @@
+import {
+  Count,
+  CountSchema,
+  Filter,
+  FilterExcludingWhere,
+  Where,
+} from '@loopback/repository';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  put,
+  requestBody,
+  response,
+} from '@loopback/rest';
+import {
+  ModifiedRestService,
+  restService,
+} from '../../../../../components/proxy-builder';
+import {Parent} from '../models';
+
+export class ParentController {
+  constructor(
+    @restService(Parent)
+    public parentRepo: ModifiedRestService<Parent>,
+  ) {}
+
+  @post('/parents')
+  @response(200, {
+    description: 'Parent model instance',
+    content: {'application/json': {schema: getModelSchemaRef(Parent)}},
+  })
+  async create(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Parent, {
+            title: 'NewParent',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    parent: Omit<Parent, 'id'>,
+  ): Promise<Parent> {
+    return this.parentRepo.create(parent);
+  }
+
+  @get('/parents/count')
+  @response(200, {
+    description: 'Parent model count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async count(@param.where(Parent) where?: Where<Parent>): Promise<Count> {
+    return this.parentRepo.count(where);
+  }
+
+  @get('/parents')
+  @response(200, {
+    description: 'Array of Parent model instances',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'array',
+          items: getModelSchemaRef(Parent, {includeRelations: true}),
+        },
+      },
+    },
+  })
+  async find(@param.filter(Parent) filter?: Filter<Parent>): Promise<Parent[]> {
+    return this.parentRepo.find(filter);
+  }
+
+  @patch('/parents')
+  @response(200, {
+    description: 'Parent PATCH success count',
+    content: {'application/json': {schema: CountSchema}},
+  })
+  async updateAll(
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Parent, {partial: true}),
+        },
+      },
+    })
+    parent: Parent,
+    @param.where(Parent) where?: Where<Parent>,
+  ): Promise<Count> {
+    return this.parentRepo.update(parent, where);
+  }
+
+  @get('/parents/{id}')
+  @response(200, {
+    description: 'Parent model instance',
+    content: {
+      'application/json': {
+        schema: getModelSchemaRef(Parent, {includeRelations: true}),
+      },
+    },
+  })
+  async findById(
+    @param.path.string('id') id: string,
+    @param.filter(Parent, {exclude: 'where'})
+    filter?: FilterExcludingWhere<Parent>,
+  ): Promise<Parent> {
+    return this.parentRepo.findById(id, filter);
+  }
+
+  @patch('/parents/{id}')
+  @response(204, {
+    description: 'Parent PATCH success',
+  })
+  async updateById(
+    @param.path.string('id') id: string,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Parent, {partial: true}),
+        },
+      },
+    })
+    parent: Parent,
+  ): Promise<void> {
+    await this.parentRepo.updateById(id, parent);
+  }
+
+  @put('/parents/{id}')
+  @response(204, {
+    description: 'Parent PUT success',
+  })
+  async replaceById(
+    @param.path.string('id') id: string,
+    @requestBody() parent: Parent,
+  ): Promise<void> {
+    await this.parentRepo.replaceById(id, parent);
+  }
+
+  @del('/parents/{id}')
+  @response(204, {
+    description: 'Parent DELETE success',
+  })
+  async deleteById(@param.path.string('id') id: string): Promise<void> {
+    await this.parentRepo.deleteById(id);
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/index.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/index.ts
@@ -1,0 +1,2 @@
+// export * from './datasources';
+export * from './models';

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/child.model.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/child.model.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  belongsTo,
+  hasMany,
+  model,
+  property,
+} from '@loopback/repository';
+import {Parent} from './parent.model';
+import {Sibling} from './sibling.model';
+
+@model({
+  name: 'children',
+  settings: {
+    rest: {
+      basePath: '/rest-children',
+    },
+  },
+})
+export class Child extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+  })
+  id?: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  name: string;
+
+  @belongsTo(() => Parent, {keyTo: 'id', name: 'parent'})
+  parentId: string;
+
+  @hasMany(() => Sibling, {keyTo: 'firstChildId', name: 'siblingRelations'})
+  siblingRelations: Sibling[];
+
+  @hasMany(() => Child, {
+    through: {
+      model: () => Sibling,
+      keyFrom: 'firstChildId',
+      keyTo: 'secondChildId',
+    },
+  })
+  siblings: Child[];
+
+  constructor(data?: Partial<Child>) {
+    super(data);
+  }
+}
+
+export interface ChildRelations {
+  parent: Parent;
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/index.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/index.ts
@@ -1,0 +1,4 @@
+export * from './parent.model';
+export * from './child.model';
+export * from './parent-config.model';
+export * from './sibling.model';

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/parent-config.model.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/parent-config.model.ts
@@ -1,0 +1,33 @@
+import {Entity, model, property} from '@loopback/repository';
+import {Parent} from './parent.model';
+
+@model({
+  name: 'rest-parent-configs',
+})
+export class ParentConfig extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+  })
+  id?: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  config: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  parentId: string;
+
+  constructor(data?: Partial<ParentConfig>) {
+    super(data);
+  }
+}
+
+export interface ParentConfigRelations {
+  parent: Parent;
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/parent.model.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/parent.model.ts
@@ -1,0 +1,30 @@
+import {Entity, hasMany, hasOne, model, property} from '@loopback/repository';
+import {Child} from './child.model';
+import {ParentConfig} from './parent-config.model';
+
+@model()
+export class Parent extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+  })
+  id?: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  name: string;
+
+  @hasMany(() => Child, {keyTo: 'parentId', name: 'children'})
+  children: Child[];
+
+  @hasOne(() => ParentConfig, {keyTo: 'parentId', name: 'config'})
+  config: ParentConfig;
+
+  constructor(data?: Partial<Parent>) {
+    super(data);
+  }
+}
+
+export interface ParentRelations {}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/sibling.model.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/models/sibling.model.ts
@@ -1,0 +1,28 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Sibling extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+  })
+  id?: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  firstChildId: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  secondChildId: string;
+
+  constructor(data?: Partial<Sibling>) {
+    super(data);
+  }
+}
+
+export interface SiblingRelations {}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/child.repository.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/child.repository.ts
@@ -1,0 +1,36 @@
+import {
+  DefaultCrudRepository,
+  HasManyRepositoryFactory,
+  juggler,
+  repository,
+} from '@loopback/repository';
+import {Child, ChildRelations, Sibling} from '../models';
+import {Getter, inject} from '@loopback/core';
+import {SiblingRepository} from './sibling.repository';
+
+export class ChildRepository extends DefaultCrudRepository<
+  Child,
+  typeof Child.prototype.id,
+  ChildRelations
+> {
+  public readonly siblingRelations: HasManyRepositoryFactory<
+    Sibling,
+    typeof Child.prototype.id
+  >;
+  constructor(
+    @inject('datasources.db')
+    dataSource: juggler.DataSource,
+    @repository.getter('SiblingRepository')
+    protected siblingRelationsRepositoryGetter: Getter<SiblingRepository>,
+  ) {
+    super(Child, dataSource);
+    this.siblingRelations = this.createHasManyRepositoryFactoryFor(
+      'siblingRelations',
+      siblingRelationsRepositoryGetter,
+    );
+    this.registerInclusionResolver(
+      'siblingRelations',
+      this.siblingRelations.inclusionResolver,
+    );
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/index.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/index.ts
@@ -1,0 +1,4 @@
+export * from './child.repository';
+export * from './parent.repository';
+export * from './parent-config.repository';
+export * from './sibling.repository';

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/parent-config.repository.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/parent-config.repository.ts
@@ -1,0 +1,16 @@
+import {DefaultCrudRepository, juggler} from '@loopback/repository';
+import {ParentConfig, ParentConfigRelations} from '../models';
+import {inject} from '@loopback/core';
+
+export class ParentConfigRepository extends DefaultCrudRepository<
+  ParentConfig,
+  typeof ParentConfig.prototype.id,
+  ParentConfigRelations
+> {
+  constructor(
+    @inject('datasources.db')
+    dataSource: juggler.DataSource,
+  ) {
+    super(ParentConfig, dataSource);
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/parent.repository.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/parent.repository.ts
@@ -1,0 +1,16 @@
+import {DefaultCrudRepository, juggler} from '@loopback/repository';
+import {Parent, ParentRelations} from '../models';
+import {inject} from '@loopback/core';
+
+export class ParentRepository extends DefaultCrudRepository<
+  Parent,
+  typeof Parent.prototype.id,
+  ParentRelations
+> {
+  constructor(
+    @inject('datasources.db')
+    dataSource: juggler.DataSource,
+  ) {
+    super(Parent, dataSource);
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/sibling.repository.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/repositories/sibling.repository.ts
@@ -1,0 +1,16 @@
+import {DefaultCrudRepository, juggler} from '@loopback/repository';
+import {Sibling, SiblingRelations} from '../models';
+import {inject} from '@loopback/core';
+
+export class SiblingRepository extends DefaultCrudRepository<
+  Sibling,
+  typeof Sibling.prototype.id,
+  SiblingRelations
+> {
+  constructor(
+    @inject('datasources.db')
+    dataSource: juggler.DataSource,
+  ) {
+    super(Sibling, dataSource);
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/fixtures/test.application.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/fixtures/test.application.ts
@@ -1,0 +1,79 @@
+import {BootMixin} from '@loopback/boot';
+import {ApplicationConfig} from '@loopback/core';
+import {RepositoryMixin} from '@loopback/repository';
+import {RestApplication} from '@loopback/rest';
+import {ServiceMixin} from '@loopback/service-proxy';
+import {
+  ProxyBuilderBindings,
+  ProxyBuilderComponent,
+} from '../../../../components/proxy-builder';
+import {
+  ParentController,
+  RestChildController,
+  RestParentConfigController,
+  RestParentController,
+} from './controllers';
+import {Child, Parent, ParentConfig} from './models';
+
+export class TestApp extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    super(options);
+    this.model(Child);
+    this.model(Parent);
+    this.model(ParentConfig);
+    this.bind(ProxyBuilderBindings.CONFIG).to([
+      {
+        baseUrl: `http://127.0.0.1:3000`,
+        configs: [
+          {
+            model: Parent,
+            basePath: '/rest-parents',
+            relations: [
+              {
+                name: 'children',
+                serviceKey: `services.ChildProxy`,
+              },
+              {
+                name: 'config',
+                serviceKey: `services.ParentConfigProxy`,
+              },
+            ],
+          },
+          {
+            model: Child,
+            relations: [
+              {
+                name: 'parent',
+                modelClass: Parent,
+              },
+              {
+                name: 'siblings',
+                serviceKey: 'services.ChildProxy',
+                throughRelation: 'siblingRelations',
+              },
+            ],
+          },
+          ParentConfig,
+        ],
+      },
+    ]);
+    this.component(ProxyBuilderComponent);
+    this.controller(ParentController);
+    this.controller(RestChildController);
+    this.controller(RestParentController);
+    this.controller(RestParentConfigController);
+
+    this.projectRoot = __dirname;
+    // Customize @loopback/boot Booter Conventions here
+    this.bootOptions = {
+      controllers: {
+        // Customize ControllerBooter Conventions here
+        dirs: ['controllers'],
+        extensions: ['.controller.js'],
+        nested: true,
+      },
+    };
+  }
+}

--- a/packages/core/src/__tests__/integration/proxy-builder/rest-service-modifier.integration.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/rest-service-modifier.integration.ts
@@ -1,0 +1,255 @@
+import {Context} from '@loopback/core';
+import {AnyObject, DataObject} from '@loopback/repository';
+import {RestBindings} from '@loopback/rest';
+import {expect} from '@loopback/testlab';
+import {ModifiedRestService} from '../../../components/proxy-builder';
+import {
+  Child,
+  ChildRelations,
+  Parent,
+  ParentConfig,
+  ParentRelations,
+} from './fixtures';
+import {
+  ChildRepository,
+  ParentConfigRepository,
+  ParentRepository,
+  SiblingRepository,
+} from './fixtures/repositories';
+import {TestApp} from './fixtures/test.application';
+import {setupApplication} from './test-helper';
+
+describe('RestServiceModifier', () => {
+  let childProxy: ModifiedRestService<Child & ChildRelations>;
+  let parentProxy: ModifiedRestService<Parent>;
+  let parentRepo: ParentRepository;
+  let childRepo: ChildRepository;
+  let siblingRepo: SiblingRepository;
+  let parentConfigRepo: ParentConfigRepository;
+  let dummyParents: DataObject<Parent>[] = [];
+  let dummyChildren: DataObject<Child>[] = [];
+  let dummyConfigs: DataObject<ParentConfig>[] = [];
+  let secondDummyChildrens: DataObject<Child>[] = [];
+  let app: TestApp;
+  before('setupApplication', async () => {
+    ({app} = await setupApplication());
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  beforeEach(async () => {
+    const requestContext = new Context(app);
+    requestContext.bind<AnyObject>(RestBindings.Http.REQUEST).to({
+      headers: {
+        authorization: 'token',
+      },
+    });
+    childProxy = await requestContext.get<
+      ModifiedRestService<Child & ChildRelations>
+    >('services.ChildProxy');
+    parentProxy = await requestContext.get<
+      ModifiedRestService<Parent & ParentRelations>
+    >('services.ParentProxy');
+    parentRepo = await requestContext.get<ParentRepository>(
+      'repositories.ParentRepository',
+    );
+    childRepo = await requestContext.get<ChildRepository>(
+      'repositories.ChildRepository',
+    );
+    parentConfigRepo = await requestContext.get<ParentConfigRepository>(
+      'repositories.ParentConfigRepository',
+    );
+    siblingRepo = await requestContext.get<SiblingRepository>(
+      'repositories.SiblingRepository',
+    );
+    await seedData();
+  });
+  afterEach(async () => {
+    await parentRepo.deleteAll();
+    await childRepo.deleteAll();
+    await parentConfigRepo.deleteAll();
+    await siblingRepo.deleteAll();
+  });
+
+  it('should not require token for a get request', async () => {
+    const result = await childProxy.find();
+    expect(result).to.have.length(6);
+  });
+
+  it('should not require token for a get by id request', async () => {
+    const result = await childProxy.findById('childId-0');
+    expect(result).to.not.be.undefined();
+  });
+
+  it('should not require token for a count request', async () => {
+    const result = await childProxy.count();
+    expect(result).to.be.deepEqual({count: 6});
+  });
+
+  it('should require token for a post request', async () => {
+    const result = await childProxy.create({
+      name: 'child-4',
+      parentId: 'id-0',
+    });
+    expect(result).to.not.be.undefined();
+    const child = await childRepo.findById(result.id);
+    expect(child).to.not.be.undefined();
+    expect(child.name).to.be.equal('child-4');
+  });
+
+  it('should require token for a patch request', async () => {
+    await childProxy.updateById('childId-0', {
+      name: 'child-4',
+    });
+    const result = await childProxy.findById('childId-0');
+    expect(result).to.not.be.undefined();
+    expect(result.name).to.be.equal('child-4');
+  });
+
+  describe('BelongsTo', () => {
+    it('should fetch related model data if a rest relation name is included', async () => {
+      const result = await childProxy.find({
+        include: ['parent'],
+      });
+      expect(result).to.have.length(6);
+      expect(result[0]).to.have.property('parent');
+      expect(result[0].parent).to.deepEqual(dummyParents[0]);
+      expect(result[1].parent).to.not.be.undefined();
+    });
+    it('should fetch related model data if a rest relation object is included', async () => {
+      const result = await childProxy.find({
+        include: [
+          {
+            relation: 'parent',
+            scope: {
+              where: {
+                id: 'id-0',
+              },
+            },
+          },
+        ],
+      });
+      expect(result).to.have.length(6);
+      expect(result[0]).to.have.property('parent');
+      expect(result[0].parent).to.deepEqual(dummyParents[0]);
+      expect(result[1].parent).to.be.undefined();
+      expect(result[2].parent).to.be.undefined();
+    });
+  });
+
+  describe('HasMany', () => {
+    it('should fetch related model data if a rest relation name is included', async () => {
+      const result = await parentProxy.find({
+        include: ['children'],
+      });
+      expect(result).to.have.length(3);
+      expect(result[0]).to.have.property('children');
+      expect(result[0].children).to.have.length(2);
+      expect(result[0].children[0]).to.deepEqual(dummyChildren[0]);
+      expect(result[0].children[1]).to.deepEqual(secondDummyChildrens[0]);
+    });
+    it('should fetch related model data if a rest relation object is included', async () => {
+      const result = await parentProxy.find({
+        include: [
+          {
+            relation: 'children',
+          },
+        ],
+      });
+      expect(result).to.have.length(3);
+      expect(result[0]).to.have.property('children');
+      expect(result[0].children).to.have.length(2);
+      expect(result[0].children[0]).to.deepEqual(dummyChildren[0]);
+      expect(result[0].children[1]).to.deepEqual(secondDummyChildrens[0]);
+    });
+  });
+
+  describe('HasManyThrough', () => {
+    it('should fetch related model data if a rest relation name is included', async () => {
+      const result = await childProxy.find({
+        include: ['siblings'],
+      });
+      expect(result).to.have.length(6);
+      expect(result[0]).to.have.property('siblings');
+    });
+    it('should fetch related model data if a rest relation object is included', async () => {
+      const result = await childProxy.find({
+        include: [
+          {
+            relation: 'siblings',
+          },
+        ],
+      });
+      expect(result).to.have.length(6);
+      expect(result[0]).to.have.property('siblings');
+      expect(result[0].siblings).to.have.length(1);
+    });
+  });
+
+  describe('HasOne', () => {
+    it('should fetch related model data if a rest relation name is included', async () => {
+      const result = await parentProxy.find({
+        include: ['config'],
+      });
+      expect(result).to.have.length(3);
+      expect(result[0]).to.have.property('config');
+      expect(result[0].config).to.deepEqual(dummyConfigs[0]);
+    });
+    it('should fetch related model data if a rest relation object is included', async () => {
+      const result = await parentProxy.find({
+        include: [
+          {
+            relation: 'config',
+          },
+        ],
+      });
+      expect(result).to.have.length(3);
+      expect(result[0]).to.have.property('config');
+      expect(result[0].config).to.deepEqual(dummyConfigs[0]);
+    });
+  });
+
+  async function seedData() {
+    dummyParents = dummyParentBuilder(3);
+    dummyChildren = dummyChildBuilder(3);
+    secondDummyChildrens = dummyChildBuilder(3, 'secondChildId');
+    dummyConfigs = dummyConfigBuilder(3);
+    await parentRepo.createAll(dummyParents);
+    await childRepo.createAll(dummyChildren);
+    await childRepo.createAll(secondDummyChildrens);
+    await parentConfigRepo.createAll(dummyConfigs);
+    await siblingRepo.create({
+      firstChildId: dummyChildren[0].id,
+      secondChildId: secondDummyChildrens[0].id,
+    });
+  }
+
+  function dummyParentBuilder(count = 1) {
+    return new Array(count).fill(0).map((_, i) => {
+      return {
+        id: `id-${i}`,
+        name: `parent ${i}`,
+      };
+    });
+  }
+  function dummyChildBuilder(count = 1, idPrefix = 'childId') {
+    return new Array(count).fill(0).map((_, i) => {
+      return {
+        id: `${idPrefix}-${i}`,
+        name: `child ${i}`,
+        parentId: `id-${i}`,
+      };
+    });
+  }
+  function dummyConfigBuilder(count = 1) {
+    return new Array(count).fill(0).map((_, i) => {
+      return {
+        id: `configId-${i}`,
+        config: `config ${i}`,
+        parentId: `id-${i}`,
+      };
+    });
+  }
+});

--- a/packages/core/src/__tests__/integration/proxy-builder/test-helper.ts
+++ b/packages/core/src/__tests__/integration/proxy-builder/test-helper.ts
@@ -1,0 +1,48 @@
+import {juggler} from '@loopback/repository';
+import {
+  Client,
+  createRestAppClient,
+  givenHttpServerConfig,
+} from '@loopback/testlab';
+import {TestApp} from './fixtures/test.application';
+
+export async function setupApplication(): Promise<AppWithClient> {
+  const restConfig = givenHttpServerConfig({
+    // Customize the server configuration here.
+    // Empty values (undefined, '') will be ignored by the helper.
+    //
+    // host: process.env.HOST,
+    host: '127.0.0.1',
+    port: 3000,
+  });
+  setUpEnv();
+  const app = new TestApp({
+    rest: restConfig,
+  });
+
+  app.bind('datasources.db').to(
+    new juggler.DataSource({
+      name: 'db',
+      connector: 'memory',
+    }),
+  );
+
+  await app.boot();
+  await app.start();
+
+  const client = createRestAppClient(app);
+
+  return {app, client};
+}
+
+function setUpEnv() {
+  process.env.NODE_ENV = 'test';
+  process.env.ENABLE_TRACING = '0';
+  process.env.ENABLE_OBF = '0';
+  process.env.REDIS_NAME = 'redis';
+}
+
+export interface AppWithClient {
+  app: TestApp;
+  client: Client;
+}

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -4,5 +4,6 @@
 // https://opensource.org/licenses/MIT
 export * from './bearer-verifier';
 export * from './logger-extension';
+export * from './proxy-builder';
 export * from './swagger-authentication';
 export * from './tenant-utilities';

--- a/packages/core/src/components/proxy-builder/README.md
+++ b/packages/core/src/components/proxy-builder/README.md
@@ -1,0 +1,260 @@
+# ProxyBuilder Component
+
+## Overview
+
+A Loopback Component that makes it easier to connect to other REST based services by automatically building and binding datasources and services using [loopback-connector-rest](https://github.com/loopbackio/loopback-connector-rest). The proxy service generated has the following structure by default -
+
+```ts
+export type ModifiedRestService<T extends Entity> = {
+  create: (data: DataObject<T>, token?: string) => Promise<T>;
+  findById: (
+    id: string,
+    filter?: FilterExcludingWhere<T>,
+    token?: string,
+  ) => Promise<T>;
+  find: (
+    filter?: Filter<T>,
+    token?: string,
+    inclusionConfig?: RestRelationConfig,
+  ) => Promise<T[]>;
+  count: (where?: Where<T>, token?: string) => Promise<Count>;
+  updateById: (
+    id: string,
+    data: DataObject<T>,
+    token?: string,
+  ) => Promise<void>;
+  replaceById: (
+    id: string,
+    data: DataObject<T>,
+    token?: string,
+  ) => Promise<void>;
+  deleteById: (id: string, token?: string) => Promise<void>;
+  update: (
+    data: DataObject<T>,
+    where?: Where<T>,
+    token?: string,
+  ) => Promise<Count>;
+  delete: (where?: Where<T>, token?: string) => Promise<void>;
+};
+```
+
+### Usage
+
+- Create a new Loopback4 Application (If you don't have one already)
+  ```sh
+  lb4 testapp
+  ```
+- Install the sourceloop core using:
+  ```sh
+  npm i @sourceloop/core
+  ```
+- Bind a config to the `ProxyBuilderBindings.CONFIG` key -
+
+```ts
+this.bind(ProxyBuilderBindings.CONFIG).to([
+  {
+    baseUrl: `http://localhost:3000`,
+    configs: [
+      // Config with both Model class and other Configs
+      {
+        model: Parent,
+        basePath: '/rest-parents',
+        relations: [
+          {
+            name: 'children',
+            serviceKey: `services.ChildProxy`,
+          },
+          {
+            name: 'config',
+            serviceKey: `services.ParentConfigProxy`,
+          },
+        ],
+      },
+      // Config with just Model Class
+      ParentConfig,
+    ],
+  },
+]);
+```
+
+- Bind the component -
+
+```ts
+this.component(ProxyBuilderComponent);
+```
+
+- Inject the rest service in your controller -
+
+```ts
+  constructor(
+    @restService(Parent)
+    public parentProxy: ModifiedRestService<Parent>,
+  ) {}
+```
+
+- Start the application
+  ```sh
+  npm start`
+  ```
+
+### Configuration
+
+- the configuration takes an Array of type `ProxyBuilderConfig` -
+
+```ts
+type ProxyBuilderConfig = Array<{
+  configs: (EntityRestConfig | ModelConstructor<Entity>)[];
+  baseUrl: string;
+}>;
+```
+
+- `configs` property accepts an array of either -
+
+  - `ModelConstructor<Entity>` - classes extending the Loopback `Entity` class that have the same name as the `basePath` of target rest API.
+    for example -
+    if you have an API with path `parents` then the model should defined as ->
+
+  ```ts
+  @model({
+    name: 'parents',
+  })
+  export class Parent extends Entity {}
+  ```
+
+  if you gave an API with path like `rest-parents` but your model name is different, then one way to override the `basePath` would be -
+
+  ```ts
+  @model({
+    name: 'parents',
+    settings: {
+      rest: {
+        basePath: `/rest-parents`,
+      },
+    },
+  })
+  export class Parent extends Entity {}
+  ```
+
+  - `EntityRestConfig` - another way to use a custom `basePath` or other configurations in the generated proxy. It accepts the following configurations -
+    - `model` - the entity class of REST api
+    - `basePath`(optional) - base path of the REST endpoints, default value is picked from the model class according to rules mentioned in the 1st method.
+    - `relations`(optional) - array of rest relation config following the type `RestRelationConfig`. Refer Refer [this](#rest-relations) for more information.
+    - `restOperations`(optional) - array of rest templates for any custom end points following the interface - `RestOperationTemplate`. Refer [this](#custom-operations) for more information.
+
+### Custom Operations
+
+If you have an operation that is not provided by the default proxy service, you can provide your own rest template.They follow the same interface as the one used by [loopback-connector-rest](https://github.com/loopbackio/loopback-connector-rest) -
+
+```ts
+export type RestOperationTemplate = {
+  template: {
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    url: string;
+    headers?: {
+      Authorization?: '{token}' | string;
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'content-type'?: 'application/json' | string;
+      [key: string]: string | undefined;
+    };
+    path?: AnyObject;
+    query?: AnyObject;
+    options?: AnyObject & {
+      maxRedirects?: number;
+    };
+    body?: string | AnyObject;
+    fullResponse?: boolean;
+    responsePath?: string;
+  };
+  functions: {
+    [key: string]: string[];
+  };
+};
+```
+
+You provide a template while defining your proxy -
+
+```ts
+  const config = {
+    model: Parent,
+    basePath: '/rest-parents',
+    restOperations: [{
+      template: {
+        method: 'GET',
+        path: '/custom',
+      }
+      function: {
+        customFunction: ['token']
+      }
+    }]
+  }
+```
+
+Then you would have to extend the `ModifiedRestService` type to include this method -
+
+```ts
+type MyRestService = {
+  customFunction: (token: string): Promise<void>
+} & ModifiedRestService<YourModel>;
+```
+
+And then simply use this type while injecting your service -
+
+```ts
+    @restService(YourModel)
+    public customRestService: MyRestService,
+```
+
+### Rest Relations
+
+The proxy services generated through this component has an ability to fetch related information from a separate microservice, similar to the concept of cross database relations supported through inclusion resolvers in Loopback4.
+
+It currently supports the following types of relations -
+
+- BelongsTo
+- HasMany
+- HasManyThrough
+- HasOne
+
+To use such relations, you define the relation in the model in exactly the same way you would defined a database relation, but while defining the proxy config, you would have to provide a config of type `RestRelationConfig` -
+
+```ts
+export type RestRelationConfig = {
+  // name of the relation, it should be same as the one defined in the model
+  name: string;
+  // name of the through relation in case this is a hasManyThrough relation
+  throughRelation?: string;
+  // disable stringification of parameters if it is not required
+  disableStringify?: boolean;
+} & (RestRelationConfigWithClass | RestRelationConfigWithKey);
+
+export type RestRelationConfigWithKey = {
+  // binding key of the relation service that follows the `ModifiedRestService` interface
+  serviceKey: string;
+};
+export type RestRelationConfigWithClass = {
+  // service class that follows the interface `ModifiedRestService`
+  serviceClass: Function;
+};
+export type RestRelationConfigWithModelClass = {
+  // entity class that has a proxy service bound against it's name
+  modelClass: ModelConstructor<Entity>;
+};
+```
+
+for example -
+
+```ts
+[
+  {
+    name: 'parent',
+    modelClass: Parent,
+  },
+  {
+    name: 'siblings',
+    serviceKey: 'services.ChildProxy',
+    throughRelation: 'siblingRelations',
+  },
+];
+```
+
+NOTE: Rest relation use the query parameters to get related data hence using them in a bulk GET api may result in breach of the HTTP header limit in Node.js. So either avoid using rest relations in such cases, or use the [`--max-http-header-size`](https://nodejs.org/api/cli.html#--max-http-header-sizesize) flag in Node.js

--- a/packages/core/src/components/proxy-builder/component.ts
+++ b/packages/core/src/components/proxy-builder/component.ts
@@ -12,6 +12,7 @@ import {
   injectable,
 } from '@loopback/core';
 import {AnyObject, Entity, juggler} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
 import {getService} from '@loopback/service-proxy';
 import debugFactory from 'debug';
 import {CONTENT_TYPE} from '../../constants';
@@ -53,6 +54,14 @@ export class ProxyBuilderComponent implements Component {
       createBindingFromClass(BelongsToRestResolver),
       createBindingFromClass(HasManyRestResolver),
       createBindingFromClass(HasOneRestResolver),
+      Binding.bind(ProxyBuilderBindings.TOKEN_VALIDATOR).to(
+        (context: AnyObject, token?: string) => {
+          if (!token && !context.token) {
+            throw new HttpErrors.Unauthorized('No token provided');
+          }
+          return token ?? context.token;
+        },
+      ),
     ];
     if (options.length) {
       options.forEach(config => {

--- a/packages/core/src/components/proxy-builder/component.ts
+++ b/packages/core/src/components/proxy-builder/component.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {
+  Application,
+  Binding,
+  Component,
+  CoreBindings,
+  createBindingFromClass,
+  inject,
+  injectable,
+} from '@loopback/core';
+import {AnyObject, Entity, juggler} from '@loopback/repository';
+import {getService} from '@loopback/service-proxy';
+import debugFactory from 'debug';
+import {CONTENT_TYPE} from '../../constants';
+import {restProxyBuilder} from './constants';
+import {ProxyBuilderBindings} from './keys';
+import {
+  BelongsToRestResolver,
+  CrudRestService,
+  CrudRestServiceModifier,
+  HasManyRestResolver,
+  HasOneRestResolver,
+  ModelConstructor,
+  ModifiedRestService,
+  RestRelationConfig,
+  RestServiceModifier,
+} from './services';
+import {
+  EntityRestConfig,
+  ProxyBuilderConfig,
+  RestOperationTemplate,
+  isEntityRestConfig,
+} from './types';
+
+const debug = debugFactory('loopback:proxy-builder:component');
+@injectable()
+export class ProxyBuilderComponent implements Component {
+  bindings?: Binding<AnyObject>[];
+
+  constructor(
+    @inject(CoreBindings.APPLICATION_INSTANCE)
+    private readonly application: Application,
+    @inject(ProxyBuilderBindings.CONFIG)
+    private readonly options: ProxyBuilderConfig,
+  ) {
+    this.bindings = [
+      createBindingFromClass(RestServiceModifier, {
+        key: ProxyBuilderBindings.PROXY_MODIFIER,
+      }),
+      createBindingFromClass(BelongsToRestResolver),
+      createBindingFromClass(HasManyRestResolver),
+      createBindingFromClass(HasOneRestResolver),
+    ];
+    if (options.length) {
+      options.forEach(config => {
+        config.configs.forEach(modelConfig => {
+          const processConfig = this._handleConfig(modelConfig);
+          const basePath = this._createBasePath(processConfig.model);
+          this._bindDataSource(
+            processConfig.model,
+            processConfig.basePath ?? basePath,
+            processConfig.restOperations,
+            config.baseUrl,
+          );
+          this._bindService(processConfig.model, processConfig.relations);
+        });
+      });
+    }
+  }
+
+  private _handleConfig(config: EntityRestConfig | ModelConstructor<Entity>) {
+    if (isEntityRestConfig(config)) {
+      return config;
+    } else {
+      return {
+        model: config,
+      };
+    }
+  }
+
+  private _bindDataSource(
+    model: ModelConstructor<Entity>,
+    basePath: string,
+    restOperations?: RestOperationTemplate[],
+    baseUrl?: string,
+  ) {
+    if (baseUrl === undefined) {
+      throw new Error('Base url is required');
+    }
+    this.application.bind(`datasources.${model.name}ProxyDataSource`).to(
+      new juggler.DataSource({
+        name: `${model.name}Proxy`,
+        connector: 'rest',
+        baseURL: '',
+        crud: false,
+        options: {
+          baseUrl: baseUrl,
+          headers: {
+            accept: CONTENT_TYPE.JSON,
+            ['content-type']: CONTENT_TYPE.JSON,
+          },
+        },
+        operations: [...restProxyBuilder(basePath), ...(restOperations ?? [])],
+      }),
+    );
+    debug(
+      `Bound datasource for ${model.name} on key - datasources.${model.name}ProxyDataSource`,
+    );
+  }
+
+  private _bindService(
+    model: ModelConstructor<Entity>,
+    restRelations?: RestRelationConfig[],
+  ) {
+    class TempClass {
+      public dataSource: juggler.DataSource;
+      public serviceModifier: CrudRestServiceModifier<Entity>;
+
+      async value(): Promise<ModifiedRestService<Entity>> {
+        const service = await getService<CrudRestService<Entity>>(
+          this.dataSource,
+        );
+        return this.serviceModifier(service, model, restRelations ?? []);
+      }
+    }
+    inject(`datasources.${model.name}ProxyDataSource`)(
+      TempClass.prototype,
+      'dataSource',
+    );
+    inject(ProxyBuilderBindings.PROXY_MODIFIER)(
+      TempClass.prototype,
+      'serviceModifier',
+    );
+    this.application.bind(`services.${model.name}Proxy`).toProvider(TempClass);
+    debug(
+      `Bound service for ${model.name} on key - services.${model.name}Proxy`,
+    );
+  }
+
+  private _createBasePath(model: ModelConstructor<Entity>) {
+    const basePath = model.definition.settings?.rest?.basePath;
+    if (basePath) {
+      return basePath;
+    }
+    return `/${model.modelName?.toLowerCase()}`;
+  }
+}

--- a/packages/core/src/components/proxy-builder/constants.ts
+++ b/packages/core/src/components/proxy-builder/constants.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {extensionFor, injectable} from '@loopback/core';
+import {CONTENT_TYPE} from '../../constants';
+import {ServiceBuilderExtensionPoint} from './keys';
+import {RestOperationTemplate} from './types';
+
+export function restProxyBuilder(basePath: string): RestOperationTemplate[] {
+  return [
+    {
+      template: {
+        method: 'POST',
+        url: basePath,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+        body: '{body}',
+      },
+      functions: {
+        create: ['token', 'body'],
+      },
+    },
+    {
+      template: {
+        method: 'GET',
+        url: `${basePath}/{id}`,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+        query: {
+          filter: '{filter}',
+        },
+      },
+      functions: {
+        findById: ['token', 'id', 'filter'],
+      },
+    },
+    {
+      template: {
+        method: 'GET',
+        url: basePath,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+        query: {
+          filter: '{filter}',
+        },
+      },
+      functions: {
+        find: ['token', 'filter'],
+      },
+    },
+    {
+      template: {
+        method: 'PATCH',
+        url: `${basePath}/{id}`,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+        body: '{body}',
+      },
+      functions: {
+        updateById: ['token', 'id', 'body'],
+      },
+    },
+    {
+      template: {
+        method: 'DELETE',
+        url: `${basePath}/{id}`,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+      },
+      functions: {
+        deleteById: ['token', 'id'],
+      },
+    },
+    {
+      template: {
+        method: 'GET',
+        url: `${basePath}/count`,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+        query: {
+          where: '{where}',
+        },
+      },
+      functions: {
+        count: ['token', 'where'],
+      },
+    },
+    {
+      template: {
+        method: 'PUT',
+        url: `${basePath}/{id}`,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+        body: '{body}',
+      },
+      functions: {
+        replaceById: ['token', 'id', 'body'],
+      },
+    },
+    {
+      template: {
+        method: 'PATCH',
+        url: basePath,
+        headers: {
+          'content-type': CONTENT_TYPE.JSON,
+          Authorization: '{token}',
+        },
+        body: '{body}',
+        query: {
+          where: '{where}',
+        },
+      },
+      functions: {
+        update: ['token', 'body', 'where'],
+      },
+    },
+    {
+      template: {
+        method: 'DELETE',
+        url: basePath,
+        headers: {
+          Authorization: '{token}',
+        },
+        query: {
+          where: '{where}',
+        },
+      },
+      functions: {
+        delete: ['token', 'where'],
+      },
+    },
+  ];
+}
+
+export const asRestResolver = () =>
+  injectable(binding => {
+    extensionFor(ServiceBuilderExtensionPoint.key)(binding);
+    binding.tag({namespace: ServiceBuilderExtensionPoint.key});
+  });

--- a/packages/core/src/components/proxy-builder/decorators/index.ts
+++ b/packages/core/src/components/proxy-builder/decorators/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+export * from './rest-proxy.decorator';

--- a/packages/core/src/components/proxy-builder/decorators/rest-proxy.decorator.ts
+++ b/packages/core/src/components/proxy-builder/decorators/rest-proxy.decorator.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {inject} from '@loopback/core';
+import {Entity} from '@loopback/repository';
+import {ModelConstructor} from '../services';
+
+export function restService(model: ModelConstructor<Entity>) {
+  return inject(`services.${model.name}Proxy`);
+}

--- a/packages/core/src/components/proxy-builder/index.ts
+++ b/packages/core/src/components/proxy-builder/index.ts
@@ -3,6 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 export * from './component';
+export * from './constants';
 export * from './decorators';
 export * from './keys';
 export * from './services';

--- a/packages/core/src/components/proxy-builder/index.ts
+++ b/packages/core/src/components/proxy-builder/index.ts
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+export * from './component';
+export * from './decorators';
+export * from './keys';
+export * from './services';
+export * from './types';

--- a/packages/core/src/components/proxy-builder/keys.ts
+++ b/packages/core/src/components/proxy-builder/keys.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {BindingKey} from '@loopback/core';
+import {BINDING_PREFIX} from '../../constants';
+import {CrudRestServiceModifier, ModifiedRestService} from './services';
+import {ProxyBuilderConfig} from './types';
+
+export namespace ProxyBuilderBindings {
+  export const CONFIG = BindingKey.create<ProxyBuilderConfig>(
+    `${BINDING_PREFIX}.proxyBuilder.config`,
+  );
+  export const PROXY_MODIFIER = BindingKey.create<
+    CrudRestServiceModifier<never>
+  >(`${BINDING_PREFIX}.proxyBuilder.proxyModifier`);
+}
+
+export const ServiceBuilderExtensionPoint = BindingKey.create<
+  ModifiedRestService<never>
+>(`${BINDING_PREFIX}.proxyBuilder.serviceBuilder.extensionPoint`);

--- a/packages/core/src/components/proxy-builder/keys.ts
+++ b/packages/core/src/components/proxy-builder/keys.ts
@@ -3,6 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 import {BindingKey} from '@loopback/core';
+import {AnyObject} from 'loopback-datasource-juggler';
 import {BINDING_PREFIX} from '../../constants';
 import {CrudRestServiceModifier, ModifiedRestService} from './services';
 import {ProxyBuilderConfig} from './types';
@@ -14,6 +15,9 @@ export namespace ProxyBuilderBindings {
   export const PROXY_MODIFIER = BindingKey.create<
     CrudRestServiceModifier<never>
   >(`${BINDING_PREFIX}.proxyBuilder.proxyModifier`);
+  export const TOKEN_VALIDATOR = BindingKey.create<
+    (context: AnyObject, token?: string) => string
+  >(`${BINDING_PREFIX}.proxyBuilder.tokenValidator`);
 }
 
 export const ServiceBuilderExtensionPoint = BindingKey.create<

--- a/packages/core/src/components/proxy-builder/services/index.ts
+++ b/packages/core/src/components/proxy-builder/services/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+export * from './rest-resolvers';
+export * from './rest-service-modifier.provider';
+export * from './types';

--- a/packages/core/src/components/proxy-builder/services/rest-resolvers/belongs-to-resolver.service.ts
+++ b/packages/core/src/components/proxy-builder/services/rest-resolvers/belongs-to-resolver.service.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {Context, inject} from '@loopback/core';
+import {
+  BelongsToDefinition,
+  Entity,
+  Filter,
+  RelationType,
+  WhereBuilder,
+} from '@loopback/repository';
+import {asRestResolver} from '../../constants';
+import {
+  IRestResolver,
+  ModifiedRestService,
+  RestLinkerParams,
+  RestRelationConfig,
+  RestResolverParams,
+  isConfigWithKey,
+  isConfigWithModelClass,
+} from '../types';
+
+@asRestResolver()
+export class BelongsToRestResolver<T extends Entity, S extends Entity>
+  implements IRestResolver<T, S>
+{
+  type: RelationType = RelationType.belongsTo;
+  constructor(
+    @inject.context()
+    private context: Context,
+  ) {}
+  /**
+   * It takes the results of the query, finds the foreign key in each result, and then uses that key to
+   * find the related record in the related service
+   * @param  - `relationConfig` is the configuration object for the relation.
+   * @returns A map of related records.
+   */
+  async resolve({
+    relationConfig,
+    relationMetadata,
+    results,
+    scope,
+    token,
+  }: RestResolverParams<T, S> & {
+    relationMetadata: BelongsToDefinition;
+  }) {
+    const relatedService = await this.getService(relationConfig);
+    const keyFrom = (relationMetadata.keyFrom ??
+      this.toPascalCase(relationMetadata.source.name) + 'Id') as keyof T;
+    const keyTo = (relationMetadata.keyTo ?? 'id') as keyof S;
+    const filter = await this.addConditionToScope(
+      results.map(r => r[keyFrom]),
+      scope,
+    );
+    const relatedResults = await relatedService.find(
+      filter ?? {},
+      token,
+      relationConfig,
+    );
+    const relatedRecordMap = new Map<S[keyof S] | T[keyof T], S>();
+    for (const item of relatedResults) {
+      const key = item[keyTo];
+      if (!relatedRecordMap.has(key)) {
+        relatedRecordMap.set(key, item);
+      }
+    }
+    return relatedRecordMap;
+  }
+
+  /**
+   * It takes a parent object, looks up the foreign key on the parent, and then uses that foreign key to
+   * look up and link the related object in the resolvedDataMap
+   * @param  - `relationMetadata` is the metadata for the relation being linked.
+   * @returns The parent object with the relationName property set to the
+   * resolvedDataMap.get(parent[keyFrom])
+   */
+  async link({
+    relationMetadata,
+    parent,
+    resolvedDataMap,
+    token,
+  }: RestLinkerParams<T, S> & {
+    relationMetadata: BelongsToDefinition;
+  }) {
+    const keyFrom = (relationMetadata.keyFrom ??
+      this.toPascalCase(relationMetadata.source.name) + 'Id') as keyof T;
+    const relationName = relationMetadata.name as keyof T;
+    parent[relationName] = resolvedDataMap.get(parent[keyFrom]) as T[keyof T];
+    return parent;
+  }
+
+  private async addConditionToScope(ids: T[keyof T][], scope?: Filter<S>) {
+    const condition = {
+      id: {
+        inq: ids.filter(id => id), //filter out valid IDs
+      },
+    };
+    const whereBuilder = new WhereBuilder();
+    whereBuilder.and([condition, scope?.where].filter(w => !!w));
+    return {
+      ...scope,
+      where: whereBuilder.build(),
+    };
+  }
+
+  private toPascalCase(str: string) {
+    return str
+      .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
+        return index === 0 ? word.toLowerCase() : word.toUpperCase();
+      })
+      .replace(/\s+/g, '');
+  }
+
+  private async getService(config: RestRelationConfig) {
+    if (isConfigWithKey(config)) {
+      return this.context.get<ModifiedRestService<S>>(config.serviceKey);
+    } else if (isConfigWithModelClass(config)) {
+      return this.context.get<ModifiedRestService<S>>(
+        `services.${config.modelClass.name}Proxy`,
+      );
+    } else {
+      return this.context.get<ModifiedRestService<S>>(
+        `services.${config.serviceClass.name}`,
+      );
+    }
+  }
+}

--- a/packages/core/src/components/proxy-builder/services/rest-resolvers/has-many-resolver.service.ts
+++ b/packages/core/src/components/proxy-builder/services/rest-resolvers/has-many-resolver.service.ts
@@ -1,0 +1,227 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {Context, inject} from '@loopback/core';
+import {
+  AnyObject,
+  Entity,
+  Filter,
+  HasManyDefinition,
+  RelationType,
+  WhereBuilder,
+} from '@loopback/repository';
+import {asRestResolver} from '../../constants';
+import {
+  IRestResolver,
+  ModifiedRestService,
+  ResolvedMap,
+  RestLinkerParams,
+  RestRelationConfig,
+  RestResolverParams,
+  isConfigWithKey,
+  isConfigWithModelClass,
+} from '../types';
+
+@asRestResolver()
+export class HasManyRestResolver<T extends Entity, S extends Entity>
+  implements IRestResolver<T, S>
+{
+  constructor(
+    @inject.context()
+    private context: Context,
+  ) {}
+  type: RelationType = RelationType.hasMany;
+  async resolve({
+    relationConfig,
+    relationMetadata,
+    results,
+    scope,
+    token,
+  }: RestResolverParams<T, S> & {
+    relationMetadata: HasManyDefinition;
+  }): Promise<ResolvedMap<T, S>> {
+    if (relationMetadata.through) {
+      return this._resolveHasManyThrough({
+        relationConfig,
+        relationMetadata,
+        results,
+        scope,
+        token,
+      });
+    } else {
+      return this._resolveHasManyOnly({
+        relationConfig,
+        relationMetadata,
+        results,
+        scope,
+        token,
+      });
+    }
+  }
+
+  private async _resolveHasManyThrough({
+    relationConfig,
+    relationMetadata,
+    results,
+    scope,
+    token,
+  }: RestResolverParams<T, S> & {
+    relationMetadata: HasManyDefinition;
+  }) {
+    if (!relationMetadata.through) {
+      throw new Error('Through relation was expected');
+    }
+    if (!relationConfig.throughRelation) {
+      throw new Error('Through relation was expected in proxy config');
+    }
+    const relatedService = await this.getService(relationConfig);
+    const keyFromThrough =
+      relationMetadata.through.keyFrom ??
+      `${this.toPascalCase(relationMetadata.source.name)}Id`;
+    const keyToThrough =
+      relationMetadata.through.keyTo ??
+      `${this.toPascalCase(relationMetadata.target.name)}Id`;
+    const keyTo = (relationMetadata.keyTo ?? 'id') as keyof S;
+    const throughModelProperty = relationConfig.throughRelation as keyof T;
+    const idsSet = new Set<T[keyof T]>();
+    const throughMap = new Map<S[keyof S], S[keyof S]>();
+    for (const result of results) {
+      const throughData = result[throughModelProperty] as
+        | AnyObject[]
+        | undefined;
+      if (throughData) {
+        throughData.forEach(d => {
+          idsSet.add(d[keyToThrough]);
+          throughMap.set(d[keyToThrough], d[keyFromThrough]);
+        });
+      }
+    }
+    const filter = await this.addConditionToScope(
+      Array.from(idsSet),
+      keyTo as string,
+      scope,
+    );
+    const relatedResults = await this.findRelatedData(
+      relatedService,
+      filter,
+      token,
+      relationConfig,
+    );
+    const relatedRecordMap = new Map<S[keyof S] | T[keyof T], S[]>();
+    for (const item of relatedResults) {
+      const keyFrom = throughMap.get(item[keyTo]);
+      if (!keyFrom) {
+        throw new Error(
+          `No key found for ${item[keyTo]} in through model ${relationMetadata.through.model.name}`,
+        );
+      }
+      if (!relatedRecordMap.has(keyFrom)) {
+        relatedRecordMap.set(keyFrom, [item]);
+      } else {
+        relatedRecordMap.get(keyFrom)?.push(item);
+      }
+    }
+    return relatedRecordMap;
+  }
+
+  private async _resolveHasManyOnly({
+    relationConfig,
+    relationMetadata,
+    results,
+    scope,
+    token,
+  }: RestResolverParams<T, S> & {
+    relationMetadata: HasManyDefinition;
+  }) {
+    const relatedService = await this.getService(relationConfig);
+    const keyFrom = (relationMetadata.keyFrom ??
+      relationMetadata.source.getIdProperties()[0]) as keyof T;
+    const keyTo = (relationMetadata.keyTo ??
+      `${this.toPascalCase(relationMetadata.source.name)}Id`) as keyof S;
+    const filter = await this.addConditionToScope(
+      results.map(r => r[keyFrom]),
+      keyTo as string,
+      scope,
+    );
+    const relatedResults = await this.findRelatedData(
+      relatedService,
+      filter,
+      token,
+      relationConfig,
+    );
+    const relatedRecordMap = new Map<S[keyof S] | T[keyof T], S[]>();
+    for (const item of relatedResults) {
+      const key = item[keyTo];
+      if (!relatedRecordMap.has(key)) {
+        relatedRecordMap.set(key, [item]);
+      } else {
+        relatedRecordMap.get(key)?.push(item);
+      }
+    }
+    return relatedRecordMap;
+  }
+
+  async link(
+    params: RestLinkerParams<T, S> & {
+      relationMetadata: HasManyDefinition;
+    },
+  ): Promise<T> {
+    const keyFrom = (params.relationMetadata.keyFrom ??
+      params.relationMetadata.source.getIdProperties()[0]) as keyof T;
+    const relationName = params.relationMetadata.name as keyof T;
+    params.parent[relationName] = params.resolvedDataMap.get(
+      params.parent[keyFrom],
+    ) as T[keyof T];
+    return params.parent;
+  }
+
+  private async addConditionToScope(
+    ids: T[keyof T][],
+    field: string,
+    scope?: Filter<S>,
+  ) {
+    const condition = {
+      [field]: {
+        inq: ids.filter(id => id), //filter out valid IDs
+      },
+    };
+    const whereBuilder = new WhereBuilder();
+    whereBuilder.and([condition, scope?.where].filter(w => !!w));
+    return {
+      ...scope,
+      where: whereBuilder.build(),
+    };
+  }
+
+  private findRelatedData(
+    service: ModifiedRestService<S>,
+    filter: Filter<S>,
+    token?: string,
+    config?: RestRelationConfig,
+  ) {
+    return service.find(filter, token, config);
+  }
+
+  private toPascalCase(str: string) {
+    return str
+      .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
+        return index === 0 ? word.toLowerCase() : word.toUpperCase();
+      })
+      .replace(/\s+/g, '');
+  }
+
+  private async getService(config: RestRelationConfig) {
+    if (isConfigWithKey(config)) {
+      return this.context.get<ModifiedRestService<S>>(config.serviceKey);
+    } else if (isConfigWithModelClass(config)) {
+      return this.context.get<ModifiedRestService<S>>(
+        `services.${config.modelClass.name}Proxy`,
+      );
+    } else {
+      return this.context.get<ModifiedRestService<S>>(
+        `services.${config.serviceClass.name}`,
+      );
+    }
+  }
+}

--- a/packages/core/src/components/proxy-builder/services/rest-resolvers/has-one-resolver.service.ts
+++ b/packages/core/src/components/proxy-builder/services/rest-resolvers/has-one-resolver.service.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {Context, inject} from '@loopback/core';
+import {
+  Entity,
+  Filter,
+  HasOneDefinition,
+  RelationType,
+  WhereBuilder,
+} from '@loopback/repository';
+import {asRestResolver} from '../../constants';
+import {
+  IRestResolver,
+  ModifiedRestService,
+  RestLinkerParams,
+  RestRelationConfig,
+  RestResolverParams,
+  isConfigWithKey,
+  isConfigWithModelClass,
+} from '../types';
+
+@asRestResolver()
+export class HasOneRestResolver<Source extends Entity, Target extends Entity>
+  implements IRestResolver<Source, Target>
+{
+  type: RelationType = RelationType.hasOne;
+  constructor(
+    @inject.context()
+    private context: Context,
+  ) {}
+  /**
+   * It takes the results of the query, finds the foreign key in each result, and then uses that key to
+   * find the related record in the related service
+   * @param  - `relationConfig` is the configuration object for the relation.
+   * @returns A map of related records.
+   */
+  async resolve({
+    relationConfig,
+    relationMetadata,
+    results,
+    scope,
+    token,
+  }: RestResolverParams<Source, Target> & {
+    relationMetadata: HasOneDefinition;
+  }) {
+    const relatedService = await this.getService(relationConfig);
+    const keyFrom = this.getKeyFrom(relationMetadata);
+    const keyTo = (relationMetadata.keyTo ??
+      this.toPascalCase(relationMetadata.source.name) + 'Id') as keyof Target;
+    const filter = await this.addConditionToScope(
+      keyTo,
+      results.map(r => r[keyFrom]),
+      scope,
+    );
+    const relatedResults = await this.findRelatedData(
+      relatedService,
+      filter,
+      token,
+      relationConfig,
+    );
+    const relatedRecordMap = new Map<
+      Target[keyof Target] | Source[keyof Source],
+      Target
+    >();
+    for (const item of relatedResults) {
+      const key = item[keyTo];
+      if (!relatedRecordMap.has(key)) {
+        relatedRecordMap.set(key, item);
+      }
+    }
+    return relatedRecordMap;
+  }
+
+  /**
+   * It takes a parent object, looks up the foreign key on the parent, and then uses that foreign key to
+   * look up and link the related object in the resolvedDataMap
+   * @param  - `relationMetadata` is the metadata for the relation being linked.
+   * @returns The parent object with the relationName property set to the
+   * resolvedDataMap.get(parent[keyFrom])
+   */
+  async link({
+    relationMetadata,
+    parent,
+    resolvedDataMap,
+  }: RestLinkerParams<Source, Target> & {
+    relationMetadata: HasOneDefinition;
+  }) {
+    const keyFrom = this.getKeyFrom(relationMetadata);
+    const relationName = relationMetadata.name as keyof Source;
+    parent[relationName] = resolvedDataMap.get(
+      parent[keyFrom],
+    ) as Source[keyof Source];
+    return parent;
+  }
+
+  private async addConditionToScope(
+    keyTo: keyof Target,
+    ids: Source[keyof Source][],
+    scope?: Filter<Target>,
+  ) {
+    const condition = {
+      [keyTo]: {
+        inq: ids.filter(id => id), //filter out valid IDs
+      },
+    };
+    const whereBuilder = new WhereBuilder();
+    whereBuilder.and([condition, scope?.where].filter(w => !!w));
+    return {
+      ...scope,
+      where: whereBuilder.build(),
+    };
+  }
+
+  private findRelatedData(
+    service: ModifiedRestService<Target>,
+    filter: Filter<Target>,
+    token?: string,
+    config?: RestRelationConfig,
+  ) {
+    return service.find(filter, token, config);
+  }
+
+  private getKeyFrom(relationMetadata: HasOneDefinition) {
+    const sourceIdProp = relationMetadata.source.getIdProperties()?.[0];
+    if (!sourceIdProp) {
+      throw new Error('Source model does not have an id property');
+    }
+    const keyFrom = (relationMetadata.keyFrom ?? sourceIdProp) as keyof Source;
+    return keyFrom;
+  }
+
+  private toPascalCase(str: string) {
+    return str
+      .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
+        return index === 0 ? word.toLowerCase() : word.toUpperCase();
+      })
+      .replace(/\s+/g, '');
+  }
+
+  private async getService(config: RestRelationConfig) {
+    if (isConfigWithKey(config)) {
+      return this.context.get<ModifiedRestService<Target>>(config.serviceKey);
+    } else if (isConfigWithModelClass(config)) {
+      return this.context.get<ModifiedRestService<Target>>(
+        `services.${config.modelClass.name}Proxy`,
+      );
+    } else {
+      return this.context.get<ModifiedRestService<Target>>(
+        `services.${config.serviceClass.name}`,
+      );
+    }
+  }
+}

--- a/packages/core/src/components/proxy-builder/services/rest-resolvers/index.ts
+++ b/packages/core/src/components/proxy-builder/services/rest-resolvers/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+export * from './belongs-to-resolver.service';
+export * from './has-many-resolver.service';
+export * from './has-one-resolver.service';

--- a/packages/core/src/components/proxy-builder/services/rest-service-modifier.provider.ts
+++ b/packages/core/src/components/proxy-builder/services/rest-service-modifier.provider.ts
@@ -1,0 +1,306 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {
+  BindingScope,
+  extensionPoint,
+  extensions,
+  Getter,
+  inject,
+  Provider,
+} from '@loopback/core';
+import {
+  AnyObject,
+  DataObject,
+  Entity,
+  Filter,
+  FilterExcludingWhere,
+  InclusionFilter,
+  Where,
+} from '@loopback/repository';
+import {HttpErrors, Request, RestBindings} from '@loopback/rest';
+
+import {ServiceBuilderExtensionPoint} from '../keys';
+import {
+  CrudRestService,
+  CrudRestServiceModifier,
+  IRestResolver,
+  ModelConstructor,
+  ResolverWithMetadata,
+  RestRelationConfig,
+} from '../services';
+
+@extensionPoint(ServiceBuilderExtensionPoint.key, {
+  scope: BindingScope.REQUEST,
+})
+export class RestServiceModifier<T extends Entity, S extends Entity>
+  implements Provider<CrudRestServiceModifier<T>>
+{
+  private token: string;
+  private resolvers: IRestResolver<T, S>[];
+  constructor(
+    @extensions()
+    private resolverGetter: Getter<IRestResolver<T, S>[]>,
+    @inject(RestBindings.Http.REQUEST, {optional: true}) private req?: Request,
+  ) {
+    if (req?.headers.authorization) {
+      this.token = req.headers.authorization;
+    }
+  }
+  async value() {
+    this.resolvers = await this.resolverGetter();
+    return (
+      service: CrudRestService<T>,
+      model: ModelConstructor<T>,
+      config: RestRelationConfig[],
+    ) => {
+      return {
+        ...service,
+        create: this.create.bind(this, service),
+        findById: this.findById.bind(this, service, model, config),
+        find: this.find.bind(this, service, model, config),
+        count: this.count.bind(this, service),
+        updateById: this.updateById.bind(this, service),
+        deleteById: this.deleteById.bind(this, service),
+        update: this.update.bind(this, service),
+        replaceById: this.replaceById.bind(this, service),
+        delete: this.delete.bind(this, service),
+      };
+    };
+  }
+
+  create(service: CrudRestService<T>, data: DataObject<T>, token?: string) {
+    return service.create(this._validateToken(token), data);
+  }
+  async findById(
+    service: CrudRestService<T>,
+    model: ModelConstructor<T>,
+    config: RestRelationConfig[],
+    id: string,
+    filter?: FilterExcludingWhere<T>,
+    token?: string,
+  ) {
+    const {restRelations, scopeMap} = this._relationsFromFilter(config, filter);
+    const result = await service.findById(
+      this._validateToken(token),
+      id,
+      JSON.stringify(filter),
+    );
+    const resolvedResults = await this._resolveRelations(
+      restRelations,
+      scopeMap,
+      model,
+      [result],
+      token,
+    );
+    return resolvedResults[0];
+  }
+
+  async find(
+    service: CrudRestService<T>,
+    model: ModelConstructor<T>,
+    config: RestRelationConfig[],
+    filter?: Filter<T>,
+    token?: string,
+    inclusionConfig?: RestRelationConfig,
+  ) {
+    const {restRelations, scopeMap} = this._relationsFromFilter(config, filter);
+    const passedFilter = inclusionConfig?.disableStringify
+      ? filter
+      : JSON.stringify(filter);
+    const results = await service.find(
+      this._validateToken(token),
+      passedFilter,
+    );
+    return this._resolveRelations(
+      restRelations,
+      scopeMap,
+      model,
+      results,
+      token,
+    );
+  }
+
+  count(service: CrudRestService<T>, where?: Where<T>, token?: string) {
+    return service.count(this._validateToken(token), JSON.stringify(where));
+  }
+  updateById(
+    service: CrudRestService<T>,
+    id: string,
+    data: DataObject<T>,
+    token?: string,
+  ) {
+    return service.updateById(this._validateToken(token), id, data);
+  }
+  deleteById(service: CrudRestService<T>, id: string, token?: string) {
+    return service.deleteById(this._validateToken(token), id);
+  }
+  delete(service: CrudRestService<T>, where?: Where<T>, token?: string) {
+    return service.delete(this._validateToken(token), where);
+  }
+  update(
+    service: CrudRestService<T>,
+    data: DataObject<T>,
+    where?: Where<T>,
+    token?: string,
+  ) {
+    return service.update(
+      this._validateToken(token),
+      data,
+      JSON.stringify(where),
+    );
+  }
+  replaceById(
+    service: CrudRestService<T>,
+    id: string,
+    data: DataObject<T>,
+    token?: string,
+  ) {
+    return service.replaceById(this._validateToken(token), id, data);
+  }
+
+  private _validateToken(token?: string) {
+    if (!token && !this.token) {
+      throw new HttpErrors.Unauthorized('No token provided');
+    }
+    return token ?? this.token;
+  }
+
+  /**
+   * It takes a filter and a list of relations, and returns a list of relations that are REST relations,
+   * and a map of scopes for those relations
+   * @param {RestRelationConfig[]} configs - RestRelationConfig[]
+   * @param [filter] - The filter object that was passed to the find method.
+   * @returns An object with two properties: restRelations and scopeMap.
+   */
+  private _relationsFromFilter(
+    configs: RestRelationConfig[],
+    filter?: Filter<T>,
+  ) {
+    if (filter?.include) {
+      const restRelations: RestRelationConfig[] = [];
+      const normalRelations: InclusionFilter[] = [];
+      const scopeMap = new Map<string, Filter<S>>();
+      filter.include.forEach(relation => {
+        let name: string;
+        if (typeof relation === 'string') {
+          name = relation;
+        } else {
+          name = relation.relation;
+        }
+        const relationConfig = configs.find(config => config.name === name);
+        if (relationConfig) {
+          restRelations.push(relationConfig);
+          if (typeof relation !== 'string' && relation.scope) {
+            scopeMap.set(relationConfig.name, relation.scope as Filter<S>);
+          }
+        } else {
+          normalRelations.push(relation);
+        }
+      });
+      const extraIncludes = this._extraFilters(restRelations);
+      this._updateFilter(extraIncludes, filter, normalRelations);
+      return {restRelations, scopeMap};
+    }
+    return {restRelations: [], scopeMap: new Map()};
+  }
+
+  private _updateFilter(
+    extraIncludes: InclusionFilter[],
+    filter: Filter<T>,
+    normalRelations: InclusionFilter[],
+  ) {
+    if (extraIncludes.length) {
+      normalRelations.push(...extraIncludes);
+    }
+    filter.include = normalRelations;
+    if (filter.include.length === 0) {
+      delete filter.include;
+    }
+  }
+
+  private _extraFilters(configs: RestRelationConfig[]) {
+    const extraIncludes: InclusionFilter[] = [];
+    configs.forEach(config => {
+      if (config.throughRelation) {
+        extraIncludes.push({
+          relation: config.throughRelation,
+        });
+      }
+    });
+    return extraIncludes;
+  }
+
+  /**
+   * It takes a list of relations, a list of results, and a token, and returns a list of results with the
+   * relations resolved
+   * @param {RestRelationConfig[]} relations - RestRelationConfig[]
+   * @param scopeMap - Map<string, Filter<S>>
+   * @param model - The model class that we are querying
+   * @param {T[]} results - The results of the query.
+   * @param {string} token - The access token of the current user.
+   */
+  private async _resolveRelations(
+    relations: RestRelationConfig[],
+    scopeMap: Map<string, Filter<S>>,
+    model: ModelConstructor<T>,
+    results: T[],
+    token?: string,
+  ) {
+    const resolvePromises = [];
+    const indexedData: ResolverWithMetadata<T, S>[] = [];
+    for (const relationConfig of relations) {
+      const relationMetadata = model.definition.relations[relationConfig.name];
+      if (!relationMetadata) {
+        throw HttpErrors.BadRequest(
+          `No metadata with name: ${relationConfig.name}`,
+        );
+      }
+      const resolver = this.resolvers.find(
+        r => r.type === relationMetadata.type,
+      );
+      if (resolver) {
+        resolvePromises.push(
+          resolver.resolve({
+            relationConfig,
+            relationMetadata,
+            results,
+            scope: scopeMap.get(relationConfig.name),
+            token,
+          }),
+        );
+        indexedData.push({
+          metadata: relationMetadata,
+          resolver,
+        });
+      } else {
+        throw HttpErrors.BadRequest(
+          `No Resolver registered for relation type: ${relationMetadata.type}`,
+        );
+      }
+    }
+    const resolvedData = await Promise.all(resolvePromises);
+    const linkPromises: Promise<T>[] = [];
+    results.forEach(result => {
+      const relatedData: AnyObject = {};
+      indexedData.forEach(({metadata, resolver}, index) => {
+        linkPromises.push(
+          resolver.link({
+            parent: result,
+            relationMetadata: metadata,
+            resolvedDataMap: resolvedData[index],
+            token,
+          }),
+        );
+      });
+      return relatedData;
+    });
+    await Promise.all(linkPromises);
+    return results;
+  }
+
+  private _configsHaveRelations(configs: RestRelationConfig[], name: string) {
+    return configs.some(config => config.name === name);
+  }
+}

--- a/packages/core/src/components/proxy-builder/services/types.ts
+++ b/packages/core/src/components/proxy-builder/services/types.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {
+  Count,
+  DataObject,
+  Entity,
+  Filter,
+  FilterExcludingWhere,
+  Model,
+  ModelDefinition,
+  RelationMetadata,
+  RelationType,
+  Where,
+} from '@loopback/repository';
+
+export type CrudRestService<T extends Entity, S extends Entity = T> = {
+  create: (token: string, data: DataObject<T>) => Promise<T>;
+  findById: (
+    token: string,
+    id: string,
+    filter?: FilterExcludingWhere<T> | string,
+  ) => Promise<S>;
+  find: (token: string, filter?: Filter<T> | string) => Promise<S[]>;
+  count: (token: string, where?: Where<T> | string) => Promise<Count>;
+  updateById: (token: string, id: string, data: DataObject<T>) => Promise<void>;
+  replaceById: (
+    token: string,
+    id: string,
+    data: DataObject<T>,
+  ) => Promise<void>;
+  deleteById: (token: string, id: string) => Promise<void>;
+  update: (
+    token: string,
+    data: DataObject<T>,
+    where?: Where<T> | string,
+  ) => Promise<Count>;
+  delete: (token: string, where?: Where<T> | string) => Promise<void>;
+};
+
+export type CrudServiceForModel<T extends Model> = {
+  create: (token: string, data: DataObject<T>) => Promise<T>;
+  find: (token: string, filter?: Filter<T>) => Promise<T[]>;
+  count: (token: string, where?: Where<T>) => Promise<Count>;
+  update: (token: string, data: T, where?: Where<T>) => Promise<Count>;
+};
+
+export type ModifiedRestService<T extends Entity> = {
+  create: (data: DataObject<T>, token?: string) => Promise<T>;
+  findById: (
+    id: string,
+    filter?: FilterExcludingWhere<T>,
+    token?: string,
+  ) => Promise<T>;
+  find: (
+    filter?: Filter<T>,
+    token?: string,
+    inclusionConfig?: RestRelationConfig,
+  ) => Promise<T[]>;
+  count: (where?: Where<T>, token?: string) => Promise<Count>;
+  updateById: (
+    id: string,
+    data: DataObject<T>,
+    token?: string,
+  ) => Promise<void>;
+  replaceById: (
+    id: string,
+    data: DataObject<T>,
+    token?: string,
+  ) => Promise<void>;
+  deleteById: (id: string, token?: string) => Promise<void>;
+  update: (
+    data: DataObject<T>,
+    where?: Where<T>,
+    token?: string,
+  ) => Promise<Count>;
+  delete: (where?: Where<T>, token?: string) => Promise<void>;
+};
+
+export type CrudRestServiceModifier<T extends Entity> = (
+  service: CrudRestService<T>,
+  model: ModelConstructor<T>,
+  config: RestRelationConfig[],
+) => ModifiedRestService<T>;
+
+export type RestRelationConfig = {
+  name: string;
+  throughRelation?: string;
+  disableStringify?: boolean;
+} & (
+  | RestRelationConfigWithClass
+  | RestRelationConfigWithKey
+  | RestRelationConfigWithModelClass
+);
+
+export type RestRelationConfigWithKey = {
+  serviceKey: string;
+};
+export type RestRelationConfigWithClass = {
+  serviceClass: Function;
+};
+export type RestRelationConfigWithModelClass = {
+  modelClass: ModelConstructor<Entity>;
+};
+
+export function isConfigWithKey(
+  config: RestRelationConfig,
+): config is RestRelationConfig & RestRelationConfigWithKey {
+  return (config as RestRelationConfigWithKey).serviceKey !== undefined;
+}
+
+export function isConfigWithModelClass(
+  config: RestRelationConfig,
+): config is RestRelationConfig & RestRelationConfigWithModelClass {
+  return (config as RestRelationConfigWithModelClass).modelClass !== undefined;
+}
+
+export type ModelConstructor<T extends Entity> = (new () => T) & {
+  definition: ModelDefinition;
+  modelName: string;
+};
+
+export interface IRestResolver<Parent extends Entity, Child extends Entity> {
+  type: RelationType;
+  resolve(
+    params: RestResolverParams<Parent, Child>,
+  ): Promise<ResolvedMap<Parent, Child>>;
+  link(params: RestLinkerParams<Parent, Child>): Promise<Parent>;
+}
+
+export type RestResolverParams<Parent extends Entity, Child extends Entity> = {
+  relationConfig: RestRelationConfig;
+  relationMetadata: RelationMetadata;
+  results: Parent[];
+  scope?: Filter<Child>;
+  token?: string;
+};
+
+export type RestLinkerParams<Parent extends Entity, Child extends Entity> = {
+  relationMetadata: RelationMetadata;
+  parent: Parent;
+  resolvedDataMap: ResolvedMap<Parent, Child>;
+  token?: string;
+};
+
+export type ResolvedMap<Parent extends Entity, Child extends Entity> = Map<
+  Child[keyof Child] | Parent[keyof Parent],
+  Child | Child[]
+>;
+
+export type ResolverWithMetadata<T extends Entity, S extends Entity> = {
+  resolver: IRestResolver<T, S>;
+  metadata: RelationMetadata;
+};

--- a/packages/core/src/components/proxy-builder/types.ts
+++ b/packages/core/src/components/proxy-builder/types.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {AnyObject, Entity} from '@loopback/repository';
+import {ModelConstructor, RestRelationConfig} from './services';
+
+export type ProxyBuilderConfig = Array<{
+  configs: (EntityRestConfig | ModelConstructor<Entity>)[];
+  baseUrl: string;
+}>;
+
+export function isEntityRestConfig(
+  config: EntityRestConfig | ModelConstructor<Entity>,
+): config is EntityRestConfig {
+  return (config as EntityRestConfig).model !== undefined;
+}
+
+/**
+ * The `EntityRestConfig` type defines the configuration options for a RESTful entity.
+ * @property model - The "model" property is a reference to the constructor function of the entity
+ * model. It represents the data structure and behavior of the entity in your application.
+ * @property {string} basePath - The `basePath` property is an optional string that represents the base
+ * path for the REST API endpoints associated with the entity. It is used to define the URL prefix for
+ * all the endpoints related to this entity.
+ * @property {RestRelationConfig[]} relations - The `relations` property is an optional array of
+ * `RestRelationConfig` objects. Each `RestRelationConfig` object represents a relation between the
+ * current entity and another entity. It defines how the relation should be handled in the REST API.
+ * @property {RestOperationTemplate[]} restOperations - The `restOperations` property is an optional
+ * array of `RestOperationTemplate` objects. These objects define the REST operations that can be
+ * performed on the entity.
+ */
+export type EntityRestConfig = {
+  model: ModelConstructor<Entity>;
+  basePath?: string;
+  relations?: RestRelationConfig[];
+  restOperations?: RestOperationTemplate[];
+};
+
+/**
+ * The above type defines a template for a REST operation, including the method, URL, headers, path,
+ * query, options, body, and response configuration.
+ * @property template - The `template` property is an object that defines the details of a REST
+ * operation like method, url, headers, etc.
+ * @property functions - The `functions` property is an object that maps function names to an array of
+ * strings. Each string represents a path to a specific property in the response object. This allows
+ * you to extract specific data from the response and use it in your code.
+ */
+export type RestOperationTemplate = {
+  template: {
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    url: string;
+    headers?: {
+      Authorization?: '{token}' | string;
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'content-type'?: 'application/json' | string;
+      [key: string]: string | undefined;
+    };
+    path?: AnyObject;
+    query?: AnyObject;
+    options?: AnyObject & {
+      maxRedirects?: number;
+    };
+    body?: string | AnyObject;
+    fullResponse?: boolean;
+    responsePath?: string;
+  };
+  functions: {
+    [key: string]: string[];
+  };
+};

--- a/packages/core/src/components/proxy-builder/types.ts
+++ b/packages/core/src/components/proxy-builder/types.ts
@@ -6,7 +6,16 @@ import {AnyObject, Entity} from '@loopback/repository';
 import {ModelConstructor, RestRelationConfig} from './services';
 
 export type ProxyBuilderConfig = Array<{
+  /**
+   * The `configs` property in the `ProxyBuilderConfig` type is an array of either {@link EntityRestConfig} objects
+   * or constructor of Entities.
+   */
   configs: (EntityRestConfig | ModelConstructor<Entity>)[];
+  /**
+   * The `baseUrl` property in the `ProxyBuilderConfig` type is a string that represents the base URL for
+   * the REST API endpoints associated with the configured entities. It is used to define the URL prefix for all the
+   * endpoints related to the configured entities.
+   * */
   baseUrl: string;
 }>;
 
@@ -31,9 +40,33 @@ export function isEntityRestConfig(
  * performed on the entity.
  */
 export type EntityRestConfig = {
+  /**
+   * The `model` property in the `EntityRestConfig` type is used to specify the constructor function of
+   * the entity model. It represents the data structure and behavior of the entity in your application.
+   * */
   model: ModelConstructor<Entity>;
+
+  /**
+   * The `basePath?: string;` property in the `EntityRestConfig` type is an optional property that
+   * represents the base path for the REST API endpoints associated with the entity. It is used to
+   * define the URL prefix for all the endpoints related to this entity.
+   */
   basePath?: string;
+
+  /**
+   * The `relations?: RestRelationConfig[];` property in the `EntityRestConfig` type is used to define
+   * the relations between the current entity and an entity of another microservice.
+   */
   relations?: RestRelationConfig[];
+
+  /**
+   * The `restOperations` property in the `EntityRestConfig` type is an optional array of
+   * `RestOperationTemplate` objects. These objects define the REST operations that can be performed on
+   * the entity. Each `RestOperationTemplate` object contains a `template` property that defines the
+   * details of a REST operation, such as the method, URL, headers, path, query, options, body, and
+   * response configuration. The `functions` property in the `RestOperationTemplate` object maps
+   * function names to an array of strings, where each string represents a specific argument for the request
+   */
   restOperations?: RestOperationTemplate[];
 };
 
@@ -43,10 +76,14 @@ export type EntityRestConfig = {
  * @property template - The `template` property is an object that defines the details of a REST
  * operation like method, url, headers, etc.
  * @property functions - The `functions` property is an object that maps function names to an array of
- * strings. Each string represents a path to a specific property in the response object. This allows
- * you to extract specific data from the response and use it in your code.
+ * arguments for the request. Each of these arguments replaces a value in the `template` property that is
+ * written between `{}` .
  */
 export type RestOperationTemplate = {
+  /**
+   *  The `template` property is an object that defines the details of a REST
+   *  operation like method, url, headers, etc
+   */
   template: {
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     url: string;
@@ -65,6 +102,11 @@ export type RestOperationTemplate = {
     fullResponse?: boolean;
     responsePath?: string;
   };
+  /**
+   * The `functions` property is an object that maps function names to an array of
+   * arguments for the request. Each of these arguments replaces a value in the `template` property that is
+   * written between `{}`
+   */
   functions: {
     [key: string]: string[];
   };

--- a/packages/core/src/repositories/sequelize/sequelize-user-modify-crud.repository.base.ts
+++ b/packages/core/src/repositories/sequelize/sequelize-user-modify-crud.repository.base.ts
@@ -4,9 +4,9 @@
 // https://opensource.org/licenses/MIT
 import {Count, DataObject, Entity, Getter, Where} from '@loopback/repository';
 import {HttpErrors} from '@loopback/rest';
+import {SequelizeDataSource} from '@loopback/sequelize';
 import {Options} from 'loopback-datasource-juggler';
 import {AuthErrorKeys} from 'loopback4-authentication';
-import {SequelizeDataSource} from '@loopback/sequelize';
 import {SequelizeSoftCrudRepository} from 'loopback4-soft-delete/sequelize';
 
 import {IAuthUserWithPermissions} from '../../components';


### PR DESCRIPTION
## Description

- Added a `ProxyBuilderComponent` for building `loopback-connector-rest` based datasources and services automatically.
- Added relevant code to allow cross microservice relations using `RestServiceModifier`. This service in turn uses the following three services to resolve the relations - 
  - BelongsToRestResolver (for BelongsTo relation)
  - HasManyRestResolver (for HasMany and HasManyThrough relations)
  - HasOneRestResolver (for HasOne relation)
- Added relevant tests

Fixes #1679

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the style guide
- [X] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
