### PR TITLE
fix(cli):  lambda files should only be generated if opted for cdk

### DIFF
--- a/packages/cli/src/generators/microservice/index.ts
+++ b/packages/cli/src/generators/microservice/index.ts
@@ -3,22 +3,22 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 import fs from 'fs';
-import {join} from 'path';
+import { join } from 'path';
 import AppGenerator from '../../app-generator';
 import {
+  BASESERVICECOMPONENTLIST,
+  BASESERVICEDSLIST,
   DATASOURCES,
   DATASOURCE_CONNECTORS,
   MIGRATIONS,
   MIGRATION_CONNECTORS,
   SERVICES,
-  BASESERVICEDSLIST,
-  BASESERVICECOMPONENTLIST,
 } from '../../enum';
-import {AnyObject, MicroserviceOptions} from '../../types';
+import { AnyObject, MicroserviceOptions } from '../../types';
 import {
+  JSON_SPACING,
   appendDependencies,
   getDependencyVersion,
-  JSON_SPACING,
 } from '../../utils';
 const chalk = require('chalk'); //NOSONAR
 
@@ -127,7 +127,7 @@ export default class MicroserviceGenerator extends AppGenerator<MicroserviceOpti
     );
     this.projectInfo.datasourceConnector =
       DATASOURCE_CONNECTORS[
-        this.options.datasourceType ?? DATASOURCES.POSTGRES
+      this.options.datasourceType ?? DATASOURCES.POSTGRES
       ];
     this.projectInfo.datasourceConnectorName =
       this.projectInfo.datasourceConnector;
@@ -261,7 +261,7 @@ export default class MicroserviceGenerator extends AppGenerator<MicroserviceOpti
         const name = this.options.name ?? DEFAULT_NAME;
         fs.unlink(
           this.destinationPath(join('services', name, 'src', 'lambda.ts')),
-          () => {},
+          () => { },
         );
         this.log(
           this.destinationPath(join('services', name, 'src', 'lambda.ts')),
@@ -632,6 +632,7 @@ export default class MicroserviceGenerator extends AppGenerator<MicroserviceOpti
             join('services', name, 'migration', 'lambda.js'),
           ),
         );
+        this.fs.delete(join('services', name, 'migration', 'migrations', 'lambda.js'));
         this.fs.copy(
           this.destinationPath(join(MIGRATION_FOLDER, name, dbconfig)),
           this.destinationPath(join('services', name, 'migration', dbconfig)),
@@ -639,7 +640,12 @@ export default class MicroserviceGenerator extends AppGenerator<MicroserviceOpti
       } else {
         // do nothing
       }
+      this.fs.delete(join(MIGRATION_FOLDER, name, 'migrations', 'lambda.js'));
+      this.log(
+        this.destinationPath(join(MIGRATION_FOLDER, name, 'migrations', 'lambda.js')),
+      );
     }
+
   }
 
   private _migrationExists() {


### PR DESCRIPTION
lambda files should only be generated if opted for cdk

gh-1698

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1698 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
