### PR TITLE
fix(survey-service): convert survey service migrations in postgresql

### DIFF
--- a/services/survey-service/migrations/sqls/20230619123543-create-questions-down.sql
+++ b/services/survey-service/migrations/sqls/20230619123543-create-questions-down.sql
@@ -1,9 +1,9 @@
 DROP INDEX IF EXISTS idx_question_question_type;
 
 ALTER TABLE
-    questions DROP CONSTRAINT fk_question_root;
+    main.questions DROP CONSTRAINT fk_question_root;
 
 ALTER TABLE
-    questions DROP CONSTRAINT fk_question_parent;
+    main.questions DROP CONSTRAINT fk_question_parent;
 
-DROP TABLE IF EXISTS questions;
+DROP TABLE IF EXISTS main.questions;

--- a/services/survey-service/migrations/sqls/20230619123543-create-questions-down.sql
+++ b/services/survey-service/migrations/sqls/20230619123543-create-questions-down.sql
@@ -1,9 +1,9 @@
-DROP INDEX idx_question_question_type on questions;
+DROP INDEX IF EXISTS idx_question_question_type;
 
 ALTER TABLE
-    questions DROP FOREIGN KEY fk_question_root;
+    questions DROP CONSTRAINT fk_question_root;
 
 ALTER TABLE
-    questions DROP FOREIGN KEY fk_question_parent;
+    questions DROP CONSTRAINT fk_question_parent;
 
 DROP TABLE IF EXISTS questions;

--- a/services/survey-service/migrations/sqls/20230619123543-create-questions-up.sql
+++ b/services/survey-service/migrations/sqls/20230619123543-create-questions-up.sql
@@ -1,6 +1,6 @@
 CREATE TYPE question_type_enum AS ENUM ('Drop Down','Multi Selection','Scale','Single Selection','Text');
 
-CREATE TABLE questions (
+CREATE TABLE main.questions (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     uid VARCHAR(20) NOT NULL,
     name TEXT NULL,
@@ -9,8 +9,8 @@ CREATE TABLE questions (
     question_type question_type_enum NOT NULL,
     is_score_enabled BOOLEAN DEFAULT FALSE,
     is_followup_enabled BOOLEAN DEFAULT FALSE,
-    root_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    parent_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    root_question_id uuid NOT NULL,
+    parent_question_id uuid NOT NULL,
     validation JSON NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
@@ -25,14 +25,14 @@ CREATE TABLE questions (
 );
 
 ALTER TABLE
-    questions
+    main.questions
 ADD
-    CONSTRAINT fk_question_root FOREIGN KEY (root_question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_question_root FOREIGN KEY (root_question_id) REFERENCES main.questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 ALTER TABLE
-    questions
+    main.questions
 ADD
-    CONSTRAINT fk_question_parent FOREIGN KEY (parent_question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_question_parent FOREIGN KEY (parent_question_id) REFERENCES main.questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 
 CREATE OR REPLACE FUNCTION moddatetime()
@@ -46,6 +46,6 @@ END;
 $function$
 ;
 
-CREATE TRIGGER questions_before_update BEFORE UPDATE ON questions FOR EACH ROW EXECUTE FUNCTION moddatetime();
+CREATE TRIGGER questions_before_update BEFORE UPDATE ON main.questions FOR EACH ROW EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_question_question_type ON questions (question_type);
+CREATE INDEX idx_question_question_type ON main.questions (question_type);

--- a/services/survey-service/migrations/sqls/20230619123543-create-questions-up.sql
+++ b/services/survey-service/migrations/sqls/20230619123543-create-questions-up.sql
@@ -1,30 +1,26 @@
+CREATE TYPE question_type_enum AS ENUM ('Drop Down','Multi Selection','Scale','Single Selection','Text');
+
 CREATE TABLE questions (
-    id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     uid VARCHAR(20) NOT NULL,
-    name LONGTEXT NULL,
+    name TEXT NULL,
     status varchar(50) NOT NULL,
     survey_id VARCHAR(50) NULL,
-    question_type ENUM(
-        'Drop Down',
-        'Multi Selection',
-        'Scale',
-        'Single Selection',
-        'Text'
-    ) NOT NULL,
-    is_score_enabled TINYINT(1) DEFAULT FALSE,
-    is_followup_enabled TINYINT(1) DEFAULT FALSE,
-    root_question_id varchar(50) NULL,
-    parent_question_id varchar(50) NULL,
+    question_type question_type_enum NOT NULL,
+    is_score_enabled BOOLEAN DEFAULT FALSE,
+    is_followup_enabled BOOLEAN DEFAULT FALSE,
+    root_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    parent_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     validation JSON NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
@@ -38,20 +34,18 @@ ALTER TABLE
 ADD
     CONSTRAINT fk_question_parent FOREIGN KEY (parent_question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
-CREATE TRIGGER questions_before_insert BEFORE
-INSERT
-    ON questions FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
 
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
+$function$
+;
 
-CREATE TRIGGER questions_before_update BEFORE
-UPDATE
-    ON questions FOR EACH ROW BEGIN
-SET
-    new.modified_on = UTC_TIMESTAMP();
-
-END;
+CREATE TRIGGER questions_before_update BEFORE UPDATE ON questions FOR EACH ROW EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_question_question_type ON questions (question_type);

--- a/services/survey-service/migrations/sqls/20230619123601-create-question-options-down.sql
+++ b/services/survey-service/migrations/sqls/20230619123601-create-question-options-down.sql
@@ -1,7 +1,7 @@
 ALTER TABLE
-    questions_options DROP CONSTRAINT fk_option_question;
+    main.questions_options DROP CONSTRAINT fk_option_question;
 
 ALTER TABLE
-    questions_options DROP CONSTRAINT fk_option_follow_up_question;
+    main.questions_options DROP CONSTRAINT fk_option_follow_up_question;
 
-DROP TABLE question_options;
+DROP TABLE main.question_options;

--- a/services/survey-service/migrations/sqls/20230619123601-create-question-options-down.sql
+++ b/services/survey-service/migrations/sqls/20230619123601-create-question-options-down.sql
@@ -1,7 +1,7 @@
 ALTER TABLE
-    questions_options DROP FOREIGN KEY fk_option_question;
+    questions_options DROP CONSTRAINT fk_option_question;
 
 ALTER TABLE
-    questions_options DROP FOREIGN KEY fk_option_follow_up_question;
+    questions_options DROP CONSTRAINT fk_option_follow_up_question;
 
 DROP TABLE question_options;

--- a/services/survey-service/migrations/sqls/20230619123601-create-question-options-up.sql
+++ b/services/survey-service/migrations/sqls/20230619123601-create-question-options-up.sql
@@ -1,19 +1,19 @@
 CREATE TABLE question_options (
-    id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     name VARCHAR(500) NULL,
-    display_order INTEGER(100) NOT NULL,
-    score DECIMAL NULL,
-    followup_question_id varchar(50) NULL,
-    question_id varchar(100) NOT NULL,
+    display_order INTEGER NOT NULL,
+    score DECIMAL(10,0),
+    followup_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
@@ -27,18 +27,16 @@ ALTER TABLE
 ADD
     CONSTRAINT fk_option_follow_up_question FOREIGN KEY (followup_question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
-CREATE TRIGGER options_before_insert BEFORE
-INSERT
-    ON question_options FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
 
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
-
-CREATE TRIGGER options_before_update BEFORE
-UPDATE
-    ON question_options FOR EACH ROW BEGIN
-SET
-    new.modified_on = UTC_TIMESTAMP();
-
-END;
+$function$
+;
+CREATE TRIGGER options_before_update BEFORE UPDATE ON question_options FOR EACH ROW
+EXECUTE FUNCTION moddatetime();

--- a/services/survey-service/migrations/sqls/20230619123601-create-question-options-up.sql
+++ b/services/survey-service/migrations/sqls/20230619123601-create-question-options-up.sql
@@ -1,10 +1,10 @@
-CREATE TABLE question_options (
+CREATE TABLE main.question_options (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     name VARCHAR(500) NULL,
     display_order INTEGER NOT NULL,
     score DECIMAL(10,0),
-    followup_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    followup_question_id uuid NOT NULL,
+    question_id uuid NOT NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
     deleted BOOLEAN DEFAULT FALSE,
@@ -18,25 +18,14 @@ CREATE TABLE question_options (
 );
 
 ALTER TABLE
-    question_options
+    main.question_options
 ADD
-    CONSTRAINT fk_option_question FOREIGN KEY (question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_option_question FOREIGN KEY (question_id) REFERENCES main.questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 ALTER TABLE
-    question_options
+    main.question_options
 ADD
-    CONSTRAINT fk_option_follow_up_question FOREIGN KEY (followup_question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_option_follow_up_question FOREIGN KEY (followup_question_id) REFERENCES main.questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
-
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER options_before_update BEFORE UPDATE ON question_options FOR EACH ROW
+CREATE TRIGGER options_before_update BEFORE UPDATE ON main.question_options FOR EACH ROW
 EXECUTE FUNCTION moddatetime();

--- a/services/survey-service/migrations/sqls/20230621082309-create-question-templates-down.sql
+++ b/services/survey-service/migrations/sqls/20230621082309-create-question-templates-down.sql
@@ -2,4 +2,4 @@ DROP INDEX IF EXISTS idx_question_templates_status;
 
 DROP INDEX IF EXISTS idx_question_templates_is_enable_weight;
 
-DROP TABLE question_templates;
+DROP TABLE main.question_templates;

--- a/services/survey-service/migrations/sqls/20230621082309-create-question-templates-down.sql
+++ b/services/survey-service/migrations/sqls/20230621082309-create-question-templates-down.sql
@@ -1,5 +1,5 @@
-DROP INDEX idx_question_templates_status ON question_templates;
+DROP INDEX IF EXISTS idx_question_templates_status;
 
-DROP INDEX idx_question_templates_is_enable_weight ON question_templates;
+DROP INDEX IF EXISTS idx_question_templates_is_enable_weight;
 
 DROP TABLE question_templates;

--- a/services/survey-service/migrations/sqls/20230621082309-create-question-templates-up.sql
+++ b/services/survey-service/migrations/sqls/20230621082309-create-question-templates-up.sql
@@ -1,36 +1,34 @@
 CREATE TABLE question_templates (
-    id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     uid varchar(20) NOT NULL,
     name VARCHAR(500) NOT NULL,
     status varchar(50) NOT NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
-    is_enable_weight TINYINT(1) DEFAULT FALSE,
+    is_enable_weight BOOLEAN DEFAULT FALSE,
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
-CREATE TRIGGER question_templates_before_insert BEFORE
-INSERT
-    ON question_templates FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
+$function$
+;
+CREATE TRIGGER question_templates_before_update BEFORE UPDATE ON question_templates FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
 
-CREATE TRIGGER question_templates_before_update BEFORE
-UPDATE
-    ON question_templates FOR EACH ROW BEGIN
-SET
-    new.modified_on = UTC_TIMESTAMP();
-
-END;
 
 CREATE INDEX idx_question_templates_status ON question_templates (status);
 

--- a/services/survey-service/migrations/sqls/20230621082309-create-question-templates-up.sql
+++ b/services/survey-service/migrations/sqls/20230621082309-create-question-templates-up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE question_templates (
+CREATE TABLE main.question_templates (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     uid varchar(20) NOT NULL,
     name VARCHAR(500) NOT NULL,
@@ -16,20 +16,10 @@ CREATE TABLE question_templates (
     PRIMARY KEY (id)
 );
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER question_templates_before_update BEFORE UPDATE ON question_templates FOR EACH ROW
+CREATE TRIGGER question_templates_before_update BEFORE UPDATE ON main.question_templates FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
 
-CREATE INDEX idx_question_templates_status ON question_templates (status);
+CREATE INDEX idx_question_templates_status ON main.question_templates (status);
 
-CREATE INDEX idx_question_templates_is_enable_weight ON question_templates (is_enable_weight);
+CREATE INDEX idx_question_templates_is_enable_weight ON main.question_templates (is_enable_weight);

--- a/services/survey-service/migrations/sqls/20230621113225-create-template-questions-down.sql
+++ b/services/survey-service/migrations/sqls/20230621113225-create-template-questions-down.sql
@@ -5,9 +5,9 @@ DROP INDEX IF EXISTS idx_template_questions_template_id;
 DROP INDEX IF EXISTS idx_template_questions_display_order;
 
 ALTER TABLE
-    template_questions DROP CONSTRAINT fk_template_questions_question_templates;
+    main.template_questions DROP CONSTRAINT fk_template_questions_question_templates;
 
 ALTER TABLE
-    template_questions DROP CONSTRAINT fk_template_questions_question;
+    main.template_questions DROP CONSTRAINT fk_template_questions_question;
 
-DROP TABLE template_questions;
+DROP TABLE main.template_questions;

--- a/services/survey-service/migrations/sqls/20230621113225-create-template-questions-down.sql
+++ b/services/survey-service/migrations/sqls/20230621113225-create-template-questions-down.sql
@@ -1,8 +1,8 @@
-DROP INDEX idx_template_questions_question_id ON template_questions;
+DROP INDEX IF EXISTS idx_template_questions_question_id;
 
-DROP INDEX idx_template_questions_template_id ON template_questions;
+DROP INDEX IF EXISTS idx_template_questions_template_id;
 
-DROP INDEX idx_template_questions_display_order ON template_questions;
+DROP INDEX IF EXISTS idx_template_questions_display_order;
 
 ALTER TABLE
     template_questions DROP CONSTRAINT fk_template_questions_question_templates;

--- a/services/survey-service/migrations/sqls/20230621113225-create-template-questions-up.sql
+++ b/services/survey-service/migrations/sqls/20230621113225-create-template-questions-up.sql
@@ -1,20 +1,20 @@
 CREATE TABLE template_questions (
-    id varchar(50) NOT NULL,
-    template_id varchar(50) NOT NULL,
-    question_id varchar(50) NOT NULL,
-    display_order INTEGER(100) NOT NULL,
-    is_mandatory boolean DEFAULT 0,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    template_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    display_order INTEGER NOT NULL,
+    is_mandatory boolean DEFAULT FALSE,
     dependent_on_question_id varchar(50),
-    `weight` DECIMAL(5, 2) DEFAULT 0.00,
+    weight DECIMAL(5, 2) DEFAULT 0.00,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
@@ -28,21 +28,19 @@ ALTER TABLE
 ADD
     CONSTRAINT fk_template_questions_question_templates FOREIGN KEY (template_id) REFERENCES question_templates (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
-CREATE TRIGGER template_questions_before_insert BEFORE
-INSERT
-    ON template_questions FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
 
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
-
-CREATE TRIGGER template_questions_before_update BEFORE
-UPDATE
-    ON template_questions FOR EACH ROW BEGIN
-SET
-    new.modified_on = UTC_TIMESTAMP();
-
-END;
+$function$
+;
+CREATE TRIGGER template_questions_before_update BEFORE UPDATE ON template_questions FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_template_questions_question_id ON template_questions (question_id);
 

--- a/services/survey-service/migrations/sqls/20230621113225-create-template-questions-up.sql
+++ b/services/survey-service/migrations/sqls/20230621113225-create-template-questions-up.sql
@@ -1,7 +1,7 @@
-CREATE TABLE template_questions (
+CREATE TABLE main.template_questions (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    template_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    template_id uuid NOT NULL,
+    question_id uuid NOT NULL,
     display_order INTEGER NOT NULL,
     is_mandatory boolean DEFAULT FALSE,
     dependent_on_question_id varchar(50),
@@ -19,31 +19,21 @@ CREATE TABLE template_questions (
 );
 
 ALTER TABLE
-    template_questions
+    main.template_questions
 ADD
-    CONSTRAINT fk_template_questions_question FOREIGN KEY (question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_template_questions_question FOREIGN KEY (question_id) REFERENCES main.questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 ALTER TABLE
-    template_questions
+    main.template_questions
 ADD
-    CONSTRAINT fk_template_questions_question_templates FOREIGN KEY (template_id) REFERENCES question_templates (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_template_questions_question_templates FOREIGN KEY (template_id) REFERENCES main.question_templates (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER template_questions_before_update BEFORE UPDATE ON template_questions FOR EACH ROW
+CREATE TRIGGER template_questions_before_update BEFORE UPDATE ON main.template_questions FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_template_questions_question_id ON template_questions (question_id);
+CREATE INDEX idx_template_questions_question_id ON main.template_questions (question_id);
 
-CREATE INDEX idx_template_questions_template_id ON template_questions (template_id);
+CREATE INDEX idx_template_questions_template_id ON main.template_questions (template_id);
 
-CREATE INDEX idx_template_questions_display_order ON template_questions (display_order);
+CREATE INDEX idx_template_questions_display_order ON main.template_questions (display_order);

--- a/services/survey-service/migrations/sqls/20230621164240-create-survey-down.sql
+++ b/services/survey-service/migrations/sqls/20230621164240-create-survey-down.sql
@@ -1,17 +1,17 @@
-DROP INDEX idx_surveys_start_date ON surveys;
+DROP INDEX IF EXISTS idx_surveys_start_date;
 
-DROP INDEX idx_surveys_end_date ON surveys;
+DROP INDEX IF EXISTS idx_surveys_end_date;
 
-DROP INDEX idx_surveys_status ON surveys;
+DROP INDEX IF EXISTS idx_surveys_status;
 
-DROP INDEX idx_surveys_is_periodic_reassessment ON surveys;
+DROP INDEX IF EXISTS idx_surveys_is_periodic_reassessment;
 
-DROP INDEX idx_surveys_recurrence_frequency ON surveys;
+DROP INDEX IF EXISTS idx_surveys_recurrence_frequency;
 
-DROP INDEX idx_surveys_recurrence_end_date ON surveys;
+DROP INDEX IF EXISTS idx_surveys_recurrence_end_date;
 
-DROP INDEX idx_surveys_recurrence_end_after_occurrences ON surveys;
+DROP INDEX IF EXISTS idx_surveys_recurrence_end_after_occurrences;
 
-DROP INDEX idx_surveys_is_enable_weights ON surveys;
+DROP INDEX IF EXISTS idx_surveys_is_enable_weights;
 
 DROP TABLE IF EXISTS surveys;

--- a/services/survey-service/migrations/sqls/20230621164240-create-survey-down.sql
+++ b/services/survey-service/migrations/sqls/20230621164240-create-survey-down.sql
@@ -14,4 +14,4 @@ DROP INDEX IF EXISTS idx_surveys_recurrence_end_after_occurrences;
 
 DROP INDEX IF EXISTS idx_surveys_is_enable_weights;
 
-DROP TABLE IF EXISTS surveys;
+DROP TABLE IF EXISTS main.surveys;

--- a/services/survey-service/migrations/sqls/20230621164240-create-survey-up.sql
+++ b/services/survey-service/migrations/sqls/20230621164240-create-survey-up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE surveys (
+CREATE TABLE main.surveys (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     uid varchar(20) NOT NULL,
     name VARCHAR(500) NOT NULL,
@@ -24,31 +24,21 @@ CREATE TABLE surveys (
     PRIMARY KEY (id)
 );
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER surveys_before_update BEFORE UPDATE ON surveys FOR EACH ROW
+CREATE TRIGGER surveys_before_update BEFORE UPDATE ON main.surveys FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_surveys_start_date ON surveys (start_date);
+CREATE INDEX idx_surveys_start_date ON main.surveys (start_date);
 
-CREATE INDEX idx_surveys_end_date ON surveys (end_date);
+CREATE INDEX idx_surveys_end_date ON main.surveys (end_date);
 
-CREATE INDEX idx_surveys_status ON surveys (status);
+CREATE INDEX idx_surveys_status ON main.surveys (status);
 
-CREATE INDEX idx_surveys_is_periodic_reassessment ON surveys (is_periodic_reassessment);
+CREATE INDEX idx_surveys_is_periodic_reassessment ON main.surveys (is_periodic_reassessment);
 
-CREATE INDEX idx_surveys_recurrence_frequency ON surveys (recurrence_frequency);
+CREATE INDEX idx_surveys_recurrence_frequency ON main.surveys (recurrence_frequency);
 
-CREATE INDEX idx_surveys_recurrence_end_date ON surveys (recurrence_end_date);
+CREATE INDEX idx_surveys_recurrence_end_date ON main.surveys (recurrence_end_date);
 
-CREATE INDEX idx_surveys_recurrence_end_after_occurrences ON surveys (recurrence_end_after_occurrences);
+CREATE INDEX idx_surveys_recurrence_end_after_occurrences ON main.surveys (recurrence_end_after_occurrences);
 
-CREATE INDEX idx_surveys_is_enable_weights ON surveys (is_enable_weights);
+CREATE INDEX idx_surveys_is_enable_weights ON main.surveys (is_enable_weights);

--- a/services/survey-service/migrations/sqls/20230621164240-create-survey-up.sql
+++ b/services/survey-service/migrations/sqls/20230621164240-create-survey-up.sql
@@ -1,39 +1,41 @@
 CREATE TABLE surveys (
-    id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     uid varchar(20) NOT NULL,
     name VARCHAR(500) NOT NULL,
     start_date DATE,
     end_date DATE,
     status varchar(50) NOT NULL,
-    is_enable_weights TINYINT(1) DEFAULT FALSE,
-    survey_text LONGTEXT NULL,
-    base_survey_id varchar(50) NULL created_on timestamp DEFAULT current_timestamp,
+	is_periodic_reassessment BOOLEAN DEFAULT false,
+	recurrence_frequency varchar(50) NOT NULL,
+	recurrence_end_date DATE,
+	recurrence_end_after_occurrences INTEGER,
+    is_enable_weights BOOLEAN DEFAULT FALSE,
+    survey_text TEXT NULL,
+    base_survey_id varchar(50) NULL, 
+    created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
-CREATE TRIGGER surveys_before_insert BEFORE
-INSERT
-    ON surveys FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
-
-CREATE TRIGGER surveys_before_update BEFORE
-UPDATE
-    ON surveys FOR EACH ROW BEGIN
-SET
-    new.modified_on = now();
-
-END;
+$function$
+;
+CREATE TRIGGER surveys_before_update BEFORE UPDATE ON surveys FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_surveys_start_date ON surveys (start_date);
 

--- a/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-down.sql
+++ b/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-down.sql
@@ -1,13 +1,13 @@
-DROP INDEX idx_survey_questions_survey_id ON survey_questions;
+DROP INDEX IF EXISTS idx_survey_questions_survey_id;
 
-DROP INDEX idx_survey_questions_question_id ON survey_questions;
+DROP INDEX IF EXISTS idx_survey_questions_question_id;
 
 ALTER TABLE
     survey_questions drop index idx_unique;
 
 ALTER TABLE
-    survey_questions DROP FOREIGN KEY fk_survey_questions_survey_id,
-    DROP FOREIGN KEY fk_survey_questions_question_id,
-    DROP FOREIGN KEY fk_survey_questions_dependent_on_question_id;
+    survey_questions DROP CONSTRAINT fk_survey_questions_survey_id,
+    DROP CONSTRAINT fk_survey_questions_question_id,
+    DROP CONSTRAINT fk_survey_questions_dependent_on_question_id;
 
 DROP TABLE IF EXISTS survey_questions;

--- a/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-down.sql
+++ b/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-down.sql
@@ -3,11 +3,11 @@ DROP INDEX IF EXISTS idx_survey_questions_survey_id;
 DROP INDEX IF EXISTS idx_survey_questions_question_id;
 
 ALTER TABLE
-    survey_questions drop index idx_unique;
+    main.survey_questions drop index idx_unique;
 
 ALTER TABLE
-    survey_questions DROP CONSTRAINT fk_survey_questions_survey_id,
+    main.survey_questions DROP CONSTRAINT fk_survey_questions_survey_id,
     DROP CONSTRAINT fk_survey_questions_question_id,
     DROP CONSTRAINT fk_survey_questions_dependent_on_question_id;
 
-DROP TABLE IF EXISTS survey_questions;
+DROP TABLE IF EXISTS main.survey_questions;

--- a/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-up.sql
+++ b/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-up.sql
@@ -1,38 +1,22 @@
 CREATE TABLE survey_questions (
-    id varchar(50) NOT NULL,
-    survey_id varchar(50) NOT NULL,
-    question_id varchar(50) NOT NULL,
-    display_order INTEGER(100) NOT NULL,
-    is_mandatory TINYINT(1) DEFAULT FALSE,
-    dependent_on_question_id varchar(50) NULL,
-    `weight` DECIMAL(5, 2) DEFAULT 0.00,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    display_order INTEGER NOT NULL,
+    is_mandatory BOOLEAN DEFAULT FALSE,
+    dependent_on_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    weight DECIMAL(5, 2) DEFAULT 0.00,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
-
-CREATE TRIGGER survey_questions_before_insert BEFORE
-INSERT
-    ON survey_questions FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
-END;
-
-CREATE TRIGGER survey_questions_before_update BEFORE
-UPDATE
-    ON survey_questions FOR EACH ROW BEGIN
-SET
-    new.modified_on = now();
-
-END;
 
 CREATE INDEX idx_survey_questions_survey_id ON survey_questions (survey_id);
 
@@ -41,7 +25,7 @@ CREATE INDEX idx_survey_questions_question_id ON survey_questions (question_id);
 ALTER TABLE
     survey_questions
 ADD
-    UNIQUE idx_unique (`survey_id`, `question_id`);
+   CONSTRAINT idx_unique UNIQUE (survey_id, question_id);
 
 ALTER TABLE
     survey_questions

--- a/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-up.sql
+++ b/services/survey-service/migrations/sqls/20230621164337-create-survey-questions-up.sql
@@ -1,10 +1,10 @@
-CREATE TABLE survey_questions (
+CREATE TABLE main.survey_questions (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    survey_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_id uuid NOT NULL,
+    question_id uuid NOT NULL,
     display_order INTEGER NOT NULL,
     is_mandatory BOOLEAN DEFAULT FALSE,
-    dependent_on_question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    dependent_on_question_id uuid NOT NULL,
     weight DECIMAL(5, 2) DEFAULT 0.00,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
@@ -18,20 +18,20 @@ CREATE TABLE survey_questions (
     PRIMARY KEY (id)
 );
 
-CREATE INDEX idx_survey_questions_survey_id ON survey_questions (survey_id);
+CREATE INDEX idx_survey_questions_survey_id ON main.survey_questions (survey_id);
 
-CREATE INDEX idx_survey_questions_question_id ON survey_questions (question_id);
+CREATE INDEX idx_survey_questions_question_id ON main.survey_questions (question_id);
 
 ALTER TABLE
-    survey_questions
+    main.survey_questions
 ADD
    CONSTRAINT idx_unique UNIQUE (survey_id, question_id);
 
 ALTER TABLE
-    survey_questions
+    main.survey_questions
 ADD
-    CONSTRAINT fk_survey_questions_survey_id FOREIGN KEY (survey_id) REFERENCES surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT fk_survey_questions_survey_id FOREIGN KEY (survey_id) REFERENCES main.surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 ADD
-    CONSTRAINT fk_survey_questions_question_id FOREIGN KEY (question_id) REFERENCES questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT fk_survey_questions_question_id FOREIGN KEY (question_id) REFERENCES main.questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION,
 ADD
-    CONSTRAINT fk_survey_questions_dependent_on_question_id FOREIGN KEY (dependent_on_question_id) REFERENCES survey_questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_survey_questions_dependent_on_question_id FOREIGN KEY (dependent_on_question_id) REFERENCES main.survey_questions (id) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/services/survey-service/migrations/sqls/20230622111309-sections-down.sql
+++ b/services/survey-service/migrations/sqls/20230622111309-sections-down.sql
@@ -1,4 +1,4 @@
-DROP TABLE section;
+DROP TABLE main.section;
 
 ALTER TABLE
-    survey_questions DROP COLUMN section_id;
+    main.survey_questions DROP COLUMN section_id;

--- a/services/survey-service/migrations/sqls/20230622111309-sections-up.sql
+++ b/services/survey-service/migrations/sqls/20230622111309-sections-up.sql
@@ -1,35 +1,32 @@
 CREATE TABLE section (
-    id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     name VARCHAR(500) NOT NULL,
-    display_order INTEGER(100) NOT NULL,
+    display_order INTEGER NOT NULL,
     survey_id varchar(50) NOT NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
-CREATE TRIGGER section_before_insert BEFORE
-INSERT
-    ON section FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
-
-CREATE TRIGGER section_before_update BEFORE
-UPDATE
-    ON section FOR EACH ROW BEGIN
-SET
-    new.modified_on = UTC_TIMESTAMP();
-
-END;
+$function$
+;
+CREATE TRIGGER section_before_update BEFORE UPDATE ON section FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_section_survey_id ON section (survey_id);
 

--- a/services/survey-service/migrations/sqls/20230622111309-sections-up.sql
+++ b/services/survey-service/migrations/sqls/20230622111309-sections-up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE section (
+CREATE TABLE main.section (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     name VARCHAR(500) NOT NULL,
     display_order INTEGER NOT NULL,
@@ -15,22 +15,12 @@ CREATE TABLE section (
     PRIMARY KEY (id)
 );
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER section_before_update BEFORE UPDATE ON section FOR EACH ROW
+CREATE TRIGGER section_before_update BEFORE UPDATE ON main.section FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_section_survey_id ON section (survey_id);
+CREATE INDEX idx_section_survey_id ON main.section (survey_id);
 
 ALTER TABLE
-    survey_questions
+    main.survey_questions
 ADD
     COLUMN section_id VARCHAR(50);

--- a/services/survey-service/migrations/sqls/20230622111907-survey-responders-down.sql
+++ b/services/survey-service/migrations/sqls/20230622111907-survey-responders-down.sql
@@ -1,11 +1,11 @@
 ALTER TABLE
-    survey_responders DROP CONSTRAINT fk_survey_responders_survey_id;
+    main.survey_responders DROP CONSTRAINT fk_survey_responders_survey_id;
 
 DROP INDEX IF EXISTS idx_survey_responders_survey_id;
 
 DROP INDEX IF EXISTS idx_survey_responders_survey_cycle_id;
 
 ALTER TABLE
-    survey_responders DROP CONSTRAINT fk_survey_responders_survey_id;
+    main.survey_responders DROP CONSTRAINT fk_survey_responders_survey_id;
 
-DROP TABLE IF EXISTS survey_responders;
+DROP TABLE IF EXISTS main.survey_responders;

--- a/services/survey-service/migrations/sqls/20230622111907-survey-responders-down.sql
+++ b/services/survey-service/migrations/sqls/20230622111907-survey-responders-down.sql
@@ -1,11 +1,11 @@
 ALTER TABLE
-    survey_responders DROP FOREIGN KEY fk_survey_responders_survey_id;
+    survey_responders DROP CONSTRAINT fk_survey_responders_survey_id;
 
-DROP INDEX idx_survey_responders_survey_id ON survey_responders;
+DROP INDEX IF EXISTS idx_survey_responders_survey_id;
 
-DROP INDEX idx_survey_responders_survey_cycle_id ON survey_responders;
+DROP INDEX IF EXISTS idx_survey_responders_survey_cycle_id;
 
 ALTER TABLE
-    survey_responders DROP FOREIGN KEY fk_survey_responders_survey_id;
+    survey_responders DROP CONSTRAINT fk_survey_responders_survey_id;
 
 DROP TABLE IF EXISTS survey_responders;

--- a/services/survey-service/migrations/sqls/20230622111907-survey-responders-up.sql
+++ b/services/survey-service/migrations/sqls/20230622111907-survey-responders-up.sql
@@ -1,44 +1,4 @@
-CREATE TABLE survey_responders (
-    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    first_name varchar(50),
-    last_name varchar(50),
-    full_name varchar(101) GENERATED ALWAYS AS (
-        TRIM(
-            CONCAT(
-                COALESCE(first_name, ''),
-                CASE
-                    WHEN first_name IS NOT NULL AND last_name IS NOT NULL THEN ' '
-                    ELSE ''
-                END,
-                COALESCE(last_name, '')
-            )
-        )
-    ) STORED,
-    email varchar(150) NOT NULL,
-    user_id varchar(50) NULL,
-    survey_id varchar(50) NOT NULL,
-    survey_cycle_id varchar(50) NULL,
-    created_on timestamp DEFAULT current_timestamp,
-    modified_on timestamp DEFAULT current_timestamp,
-    deleted BOOLEAN DEFAULT FALSE,
-    created_by varchar(50),
-    modified_by varchar(50),
-    deleted_on timestamp NULL,
-    deleted_by varchar(50),
-    ext_id varchar(100),
-    ext_metadata jsonb,
-    PRIMARY KEY (id)
-);
-
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$CREATE TABLE survey_responders (
+CREATE TABLE main.survey_responders (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     first_name varchar(50),
     last_name varchar(50),
@@ -52,7 +12,7 @@ $function$CREATE TABLE survey_responders (
     ) STORED,
     email varchar(150) NOT NULL,
     user_id varchar(50) NULL,
-    survey_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_id uuid NOT NULL,
     survey_cycle_id varchar(50) NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
@@ -66,36 +26,27 @@ $function$CREATE TABLE survey_responders (
     PRIMARY KEY (id)
 );
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER survey_responders_before_update BEFORE UPDATE ON survey_responders FOR EACH ROW
+
+CREATE TRIGGER survey_responders_before_update BEFORE UPDATE ON main.survey_responders FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_survey_responders_survey_id ON survey_responders (survey_id);
+CREATE INDEX idx_survey_responders_survey_id ON main.survey_responders (survey_id);
 
-CREATE INDEX idx_survey_responders_survey_cycle_id ON survey_responders (survey_cycle_id);
+CREATE INDEX idx_survey_responders_survey_cycle_id ON main.survey_responders (survey_cycle_id);
 
 ALTER TABLE
-    survey_responders
+    main.survey_responders
 ADD
-    CONSTRAINT fk_survey_responders_survey_id FOREIGN KEY (survey_id) REFERENCES surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_survey_responders_survey_id FOREIGN KEY (survey_id) REFERENCES main.surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
 ;
-CREATE TRIGGER survey_responders_before_update BEFORE UPDATE ON survey_responders FOR EACH ROW
+CREATE TRIGGER survey_responders_before_update BEFORE UPDATE ON main.survey_responders FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_survey_responders_survey_id ON survey_responders (survey_id);
+CREATE INDEX idx_survey_responders_survey_id ON main.survey_responders (survey_id);
 
-CREATE INDEX idx_survey_responders_survey_cycle_id ON survey_responders (survey_cycle_id);
+CREATE INDEX idx_survey_responders_survey_cycle_id ON main.survey_responders (survey_cycle_id);
 
 ALTER TABLE
-    survey_responders
+    main.survey_responders
 ADD
-    CONSTRAINT fk_survey_responders_survey_id FOREIGN KEY (survey_id) REFERENCES surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_survey_responders_survey_id FOREIGN KEY (survey_id) REFERENCES main.surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/services/survey-service/migrations/sqls/20230622111907-survey-responders-up.sql
+++ b/services/survey-service/migrations/sqls/20230622111907-survey-responders-up.sql
@@ -1,18 +1,16 @@
 CREATE TABLE survey_responders (
-    id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     first_name varchar(50),
     last_name varchar(50),
     full_name varchar(101) GENERATED ALWAYS AS (
         TRIM(
             CONCAT(
-                IFNULL(first_name, ''),
-                IF(
-                    first_name IS NOT NULL
-                    AND last_name IS NOT NULL,
-                    ' ',
-                    ''
-                ),
-                IFNULL(last_name, '')
+                COALESCE(first_name, ''),
+                CASE
+                    WHEN first_name IS NOT NULL AND last_name IS NOT NULL THEN ' '
+                    ELSE ''
+                END,
+                COALESCE(last_name, '')
             )
         )
     ) STORED,
@@ -22,31 +20,76 @@ CREATE TABLE survey_responders (
     survey_cycle_id varchar(50) NULL,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
-CREATE TRIGGER survey_responders_before_insert BEFORE
-INSERT
-    ON survey_responders FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
+$function$CREATE TABLE survey_responders (
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    first_name varchar(50),
+    last_name varchar(50),
+    full_name varchar(101) GENERATED ALWAYS AS (
+    COALESCE(first_name, '') ||
+    CASE
+        WHEN first_name IS NOT NULL AND last_name IS NOT NULL THEN ' '
+        ELSE ''
+    END ||
+    COALESCE(last_name, '')
+    ) STORED,
+    email varchar(150) NOT NULL,
+    user_id varchar(50) NULL,
+    survey_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_cycle_id varchar(50) NULL,
+    created_on timestamp DEFAULT current_timestamp,
+    modified_on timestamp DEFAULT current_timestamp,
+    deleted BOOLEAN DEFAULT FALSE,
+    created_by varchar(50),
+    modified_by varchar(50),
+    deleted_on timestamp NULL,
+    deleted_by varchar(50),
+    ext_id varchar(100),
+    ext_metadata jsonb,
+    PRIMARY KEY (id)
+);
 
-CREATE TRIGGER survey_responders_before_update BEFORE
-UPDATE
-    ON survey_responders FOR EACH ROW BEGIN
-SET
-    new.modified_on = now();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
+$function$
+;
+CREATE TRIGGER survey_responders_before_update BEFORE UPDATE ON survey_responders FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
+
+CREATE INDEX idx_survey_responders_survey_id ON survey_responders (survey_id);
+
+CREATE INDEX idx_survey_responders_survey_cycle_id ON survey_responders (survey_cycle_id);
+
+ALTER TABLE
+    survey_responders
+ADD
+    CONSTRAINT fk_survey_responders_survey_id FOREIGN KEY (survey_id) REFERENCES surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+;
+CREATE TRIGGER survey_responders_before_update BEFORE UPDATE ON survey_responders FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_survey_responders_survey_id ON survey_responders (survey_id);
 

--- a/services/survey-service/migrations/sqls/20230622112026-survey-cycles-down.sql
+++ b/services/survey-service/migrations/sqls/20230622112026-survey-cycles-down.sql
@@ -1,10 +1,10 @@
-DROP INDEX idx_survey_cycles_survey_id ON survey_cycles;
+DROP INDEX IF EXISTS idx_survey_cycles_survey_id;
 
-DROP INDEX idx_survey_cycles_start_date ON survey_cycles;
+DROP INDEX IF EXISTS idx_survey_cycles_start_date;
 
-DROP INDEX idx_survey_cycles_end_date ON survey_cycles;
+DROP INDEX IF EXISTS idx_survey_cycles_end_date;
 
 ALTER TABLE
-    survey_cycles DROP FOREIGN KEY fk_survey_cycles_survey_id;
+    survey_cycles DROP CONSTRAINT fk_survey_cycles_survey_id;
 
 DROP TABLE IF EXISTS survey_cycles;

--- a/services/survey-service/migrations/sqls/20230622112026-survey-cycles-down.sql
+++ b/services/survey-service/migrations/sqls/20230622112026-survey-cycles-down.sql
@@ -5,6 +5,6 @@ DROP INDEX IF EXISTS idx_survey_cycles_start_date;
 DROP INDEX IF EXISTS idx_survey_cycles_end_date;
 
 ALTER TABLE
-    survey_cycles DROP CONSTRAINT fk_survey_cycles_survey_id;
+    main.survey_cycles DROP CONSTRAINT fk_survey_cycles_survey_id;
 
 DROP TABLE IF EXISTS survey_cycles;

--- a/services/survey-service/migrations/sqls/20230622112026-survey-cycles-up.sql
+++ b/services/survey-service/migrations/sqls/20230622112026-survey-cycles-up.sql
@@ -1,36 +1,33 @@
 CREATE TABLE survey_cycles (
-    id varchar(50) NOT NULL,
-    survey_id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     start_date DATE NOT NULL,
     end_date DATE NOT NULL,
-    is_activated TINYINT(1) DEFAULT FALSE,
+    is_activated BOOLEAN DEFAULT FALSE,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
-CREATE TRIGGER survey_cycles_before_insert BEFORE
-INSERT
-    ON survey_cycles FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
-
-CREATE TRIGGER survey_cycles_before_update BEFORE
-UPDATE
-    ON survey_cycles FOR EACH ROW BEGIN
-SET
-    new.modified_on = now();
-
-END;
+$function$
+;
+CREATE TRIGGER survey_cycles_before_update BEFORE UPDATE ON survey_cycles FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_survey_cycles_survey_id ON survey_cycles (survey_id);
 

--- a/services/survey-service/migrations/sqls/20230622112026-survey-cycles-up.sql
+++ b/services/survey-service/migrations/sqls/20230622112026-survey-cycles-up.sql
@@ -1,6 +1,6 @@
-CREATE TABLE survey_cycles (
+CREATE TABLE main.survey_cycles (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    survey_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_id uuid NOT NULL,
     start_date DATE NOT NULL,
     end_date DATE NOT NULL,
     is_activated BOOLEAN DEFAULT FALSE,
@@ -16,26 +16,16 @@ CREATE TABLE survey_cycles (
     PRIMARY KEY (id)
 );
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER survey_cycles_before_update BEFORE UPDATE ON survey_cycles FOR EACH ROW
+CREATE TRIGGER survey_cycles_before_update BEFORE UPDATE ON main.survey_cycles FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_survey_cycles_survey_id ON survey_cycles (survey_id);
+CREATE INDEX idx_survey_cycles_survey_id ON main.survey_cycles (survey_id);
 
-CREATE INDEX idx_survey_cycles_start_date ON survey_cycles (start_date);
+CREATE INDEX idx_survey_cycles_start_date ON main.survey_cycles (start_date);
 
-CREATE INDEX idx_survey_cycles_end_date ON survey_cycles (end_date);
+CREATE INDEX idx_survey_cycles_end_date ON main.survey_cycles (end_date);
 
 ALTER TABLE
-    survey_cycles
+    main.survey_cycles
 ADD
-    CONSTRAINT fk_survey_cycles_survey_id FOREIGN KEY (survey_id) REFERENCES surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION;
+    CONSTRAINT fk_survey_cycles_survey_id FOREIGN KEY (survey_id) REFERENCES main.surveys (id) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-down.sql
+++ b/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-down.sql
@@ -1,10 +1,10 @@
 ALTER TABLE
-    survey_cycle_responses DROP FOREIGN KEY fk_survey_cycle_responses_survey_cycle;
+    survey_cycle_responses DROP CONSTRAINT fk_survey_cycle_responses_survey_cycle;
 
-DROP INDEX idx_survey_cycle_responses_survey_responder_id ON survey_cycle_responses;
+DROP INDEX IF EXISTS idx_survey_cycle_responses_survey_responder_id;
 
-DROP INDEX idx_survey_response_vendor_id ON survey_cycle_responses;
+DROP INDEX IF EXISTS idx_survey_response_vendor_id;
 
-DRop INDEX idx_survey_response_survey_cycle_id ON survey_cycle_responses;
+DRop INDEX IF EXISTS idx_survey_response_survey_cycle_id;
 
 DROP TABLE IF EXISTS survey_cycle_responses;

--- a/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-down.sql
+++ b/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-down.sql
@@ -1,5 +1,5 @@
 ALTER TABLE
-    survey_cycle_responses DROP CONSTRAINT fk_survey_cycle_responses_survey_cycle;
+    main.survey_cycle_responses DROP CONSTRAINT fk_survey_cycle_responses_survey_cycle;
 
 DROP INDEX IF EXISTS idx_survey_cycle_responses_survey_responder_id;
 
@@ -7,4 +7,4 @@ DROP INDEX IF EXISTS idx_survey_response_vendor_id;
 
 DRop INDEX IF EXISTS idx_survey_response_survey_cycle_id;
 
-DROP TABLE IF EXISTS survey_cycle_responses;
+DROP TABLE IF EXISTS main.survey_cycle_responses;

--- a/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-up.sql
+++ b/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE main.survey_cycle_responses (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    survey_responder_id varchar(50) NOT NULL,
+    survey_responder_id uuid NOT NULL,
     survey_cycle_id uuid NOT NULL,
     total_score DECIMAL(5, 2),
     created_on timestamp DEFAULT current_timestamp,

--- a/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-up.sql
+++ b/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-up.sql
@@ -1,7 +1,7 @@
-CREATE TABLE survey_cycle_responses (
+CREATE TABLE main.survey_cycle_responses (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     survey_responder_id varchar(50) NOT NULL,
-    survey_cycle_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_cycle_id uuid NOT NULL,
     total_score DECIMAL(5, 2),
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
@@ -16,23 +16,13 @@ CREATE TABLE survey_cycle_responses (
 );
 
 ALTER TABLE
-    survey_cycle_responses
+    main.survey_cycle_responses
 ADD
-    CONSTRAINT fk_survey_cycle_responses_survey_cycle FOREIGN KEY (survey_cycle_id) REFERENCES survey_cycles (id);
+    CONSTRAINT fk_survey_cycle_responses_survey_cycle FOREIGN KEY (survey_cycle_id) REFERENCES main.survey_cycles (id);
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
-CREATE TRIGGER survey_cycle_responses_before_update BEFORE UPDATE ON survey_cycle_responses FOR EACH ROW
+CREATE TRIGGER survey_cycle_responses_before_update BEFORE UPDATE ON main.survey_cycle_responses FOR EACH ROW
 EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_survey_cycle_responses_survey_responder_id ON survey_cycle_responses (survey_responder_id);
+CREATE INDEX idx_survey_cycle_responses_survey_responder_id ON main.survey_cycle_responses (survey_responder_id);
 
-CREATE INDEX idx_survey_response_survey_cycle_id ON survey_cycle_responses (survey_cycle_id);
+CREATE INDEX idx_survey_response_survey_cycle_id ON main.survey_cycle_responses (survey_cycle_id);

--- a/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-up.sql
+++ b/services/survey-service/migrations/sqls/20230622112223-survey-cycle-responses-up.sql
@@ -1,17 +1,17 @@
 CREATE TABLE survey_cycle_responses (
-    id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     survey_responder_id varchar(50) NOT NULL,
-    survey_cycle_id varchar(50) NOT NULL,
+    survey_cycle_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     total_score DECIMAL(5, 2),
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
@@ -20,21 +20,18 @@ ALTER TABLE
 ADD
     CONSTRAINT fk_survey_cycle_responses_survey_cycle FOREIGN KEY (survey_cycle_id) REFERENCES survey_cycles (id);
 
-CREATE TRIGGER survey_cycle_responses_before_insert BEFORE
-INSERT
-    ON survey_cycle_responses FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
-
-CREATE TRIGGER survey_cycle_responses_before_update BEFORE
-UPDATE
-    ON survey_cycle_responses FOR EACH ROW BEGIN
-SET
-    new.modified_on = UTC_TIMESTAMP();
-
-END;
+$function$
+;
+CREATE TRIGGER survey_cycle_responses_before_update BEFORE UPDATE ON survey_cycle_responses FOR EACH ROW
+EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_survey_cycle_responses_survey_responder_id ON survey_cycle_responses (survey_responder_id);
 

--- a/services/survey-service/migrations/sqls/20230622112646-survey-response-details-down.sql
+++ b/services/survey-service/migrations/sqls/20230622112646-survey-response-details-down.sql
@@ -1,10 +1,10 @@
 ALTER TABLE
-    survey_cycle_responses DROP FOREIGN KEY fk_survey_cycle_responses_survey_cycle;
+    survey_cycle_responses DROP CONSTRAINT fk_survey_cycle_responses_survey_cycle;
 
-DROP INDEX idx_survey_cycle_responses_survey_responder_id ON survey_cycle_responses;
+DROP INDEX IF EXISTS idx_survey_cycle_responses_survey_responder_id;
 
-DROP INDEX idx_survey_response_vendor_id ON survey_cycle_responses;
+DROP INDEX IF EXISTS idx_survey_response_vendor_id;
 
-DRop INDEX idx_survey_response_survey_cycle_id ON survey_cycle_responses;
+DRop INDEX IF EXISTS idx_survey_response_survey_cycle_id;
 
 DROP TABLE IF EXISTS survey_cycle_responses;

--- a/services/survey-service/migrations/sqls/20230622112646-survey-response-details-down.sql
+++ b/services/survey-service/migrations/sqls/20230622112646-survey-response-details-down.sql
@@ -1,5 +1,5 @@
 ALTER TABLE
-    survey_cycle_responses DROP CONSTRAINT fk_survey_cycle_responses_survey_cycle;
+    main.survey_cycle_responses DROP CONSTRAINT fk_survey_cycle_responses_survey_cycle;
 
 DROP INDEX IF EXISTS idx_survey_cycle_responses_survey_responder_id;
 
@@ -7,4 +7,4 @@ DROP INDEX IF EXISTS idx_survey_response_vendor_id;
 
 DRop INDEX IF EXISTS idx_survey_response_survey_cycle_id;
 
-DROP TABLE IF EXISTS survey_cycle_responses;
+DROP TABLE IF EXISTS main.survey_cycle_responses;

--- a/services/survey-service/migrations/sqls/20230622112646-survey-response-details-up.sql
+++ b/services/survey-service/migrations/sqls/20230622112646-survey-response-details-up.sql
@@ -1,9 +1,9 @@
 CREATE TYPE response_type_enum AS ENUM ('Drop Down','Multi Selection','Scale','Single Selection','Text');
 
-CREATE TABLE survey_response_details (
+CREATE TABLE main.survey_response_details (
     id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    survey_response_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
-    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_response_id uuid NOT NULL,
+    question_id uuid NOT NULL,
     score DECIMAL(5, 2),
     option_id varchar(50) NULL DEFAULT NULL,
     text_answer TEXT NULL,
@@ -21,28 +21,18 @@ CREATE TABLE survey_response_details (
 );
 
 ALTER TABLE
-    survey_response_details
+    main.survey_response_details
 ADD
-    CONSTRAINT fk_survey_response_details_survey_response FOREIGN KEY (survey_response_id) REFERENCES survey_cycle_responses (id);
+    CONSTRAINT fk_survey_response_details_survey_response FOREIGN KEY (survey_response_id) REFERENCES main.survey_cycle_responses (id);
 
 ALTER TABLE
-    survey_response_details
+    main.survey_response_details
 ADD
-    CONSTRAINT fk_survey_response_details_question FOREIGN KEY (question_id) REFERENCES questions (id);
+    CONSTRAINT fk_survey_response_details_question FOREIGN KEY (question_id) REFERENCES main.questions (id);
 
-CREATE OR REPLACE FUNCTION moddatetime()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    NEW.modified_on = now();
-    RETURN NEW;
-END;
-$function$
-;
 
-CREATE TRIGGER survey_response_details_before_update BEFORE UPDATE ON survey_response_details FOR EACH ROW EXECUTE FUNCTION moddatetime();
+CREATE TRIGGER survey_response_details_before_update BEFORE UPDATE ON main.survey_response_details FOR EACH ROW EXECUTE FUNCTION moddatetime();
 
-CREATE INDEX idx_survey_response_details_survey_response_id ON survey_response_details (survey_response_id);
+CREATE INDEX idx_survey_response_details_survey_response_id ON main.survey_response_details (survey_response_id);
 
-CREATE INDEX idx_survey_response_details_question_id ON survey_response_details (question_id);
+CREATE INDEX idx_survey_response_details_question_id ON main.survey_response_details (question_id);

--- a/services/survey-service/migrations/sqls/20230622112646-survey-response-details-up.sql
+++ b/services/survey-service/migrations/sqls/20230622112646-survey-response-details-up.sql
@@ -1,26 +1,22 @@
+CREATE TYPE response_type_enum AS ENUM ('Drop Down','Multi Selection','Scale','Single Selection','Text');
+
 CREATE TABLE survey_response_details (
-    id varchar(50) NOT NULL,
-    survey_response_id varchar(50) NOT NULL,
-    question_id varchar(50) NOT NULL,
+    id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    survey_response_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
+    question_id uuid DEFAULT (md5(((random())::text || (clock_timestamp())::text)))::uuid NOT NULL,
     score DECIMAL(5, 2),
     option_id varchar(50) NULL DEFAULT NULL,
     text_answer TEXT NULL,
-    response_type enum(
-        'Drop Down',
-        'Multi Selection',
-        'Scale',
-        'Single Selection',
-        'Text'
-    ),
+    response_type response_type_enum,
     created_on timestamp DEFAULT current_timestamp,
     modified_on timestamp DEFAULT current_timestamp,
-    deleted TINYINT(1) DEFAULT FALSE,
+    deleted BOOLEAN DEFAULT FALSE,
     created_by varchar(50),
     modified_by varchar(50),
     deleted_on timestamp NULL,
     deleted_by varchar(50),
     ext_id varchar(100),
-    ext_metadata json,
+    ext_metadata jsonb,
     PRIMARY KEY (id)
 );
 
@@ -34,21 +30,18 @@ ALTER TABLE
 ADD
     CONSTRAINT fk_survey_response_details_question FOREIGN KEY (question_id) REFERENCES questions (id);
 
-CREATE TRIGGER survey_response_details_before_insert BEFORE
-INSERT
-    ON survey_response_details FOR EACH ROW BEGIN
-SET
-    new.id = uuid();
-
+CREATE OR REPLACE FUNCTION moddatetime()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.modified_on = now();
+    RETURN NEW;
 END;
+$function$
+;
 
-CREATE TRIGGER survey_response_details_before_update BEFORE
-UPDATE
-    ON survey_response_details FOR EACH ROW BEGIN
-SET
-    new.modified_on = UTC_TIMESTAMP();
-
-END;
+CREATE TRIGGER survey_response_details_before_update BEFORE UPDATE ON survey_response_details FOR EACH ROW EXECUTE FUNCTION moddatetime();
 
 CREATE INDEX idx_survey_response_details_survey_response_id ON survey_response_details (survey_response_id);
 


### PR DESCRIPTION


MIGRATION CHANGE:
migration-20230619123543- convert survey service migrations in postgresql migration-20230619123601- convert survey service migrations in postgresql migration-20230621082309- convert survey service migrations in postgresql migration-20230621113225- convert survey service migrations in postgresql migration-20230621164240- convert survey service migrations in postgresql migration-20230621164337- convert survey service migrations in postgresql migration-20230622111309- convert survey service migrations in postgresql migration-20230622111907- convert survey service migrations in postgresql migration-20230622112026- convert survey service migrations in postgresql migration-20230622112223- convert survey service migrations in postgresql migration-20230622112646- convert survey service migrations in postgresql

## Description
Convert survey service migrations in postgresql

Fixes #1782 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
