### PR TITLE
fix(cli): change the npm ci to npm i in docker file of microservice

### DIFF
--- a/packages/cli/src/generators/microservice/templates/Dockerfile
+++ b/packages/cli/src/generators/microservice/templates/Dockerfile
@@ -42,7 +42,7 @@ COPY --chown=node packages ./packages
 COPY --chown=node $FROM_FOLDER/$SERVICE_NAME ./$FROM_FOLDER/$SERVICE_NAME
 
 # Installing all dependencies
-RUN npm ci
+RUN npm install
 
 # Building the app
 # set the Working Directory to the service


### PR DESCRIPTION
gh-1830

## Description

the npm ci command in dockerfile throws error as it requires package-lock.json file
changed the npm ci to npm i 

Fixes #1830

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
