### PR TITLE
feat(task-service): delete process instances on Camunda for deleted tasks

### DIFF
--- a/services/task-service/src/__tests__/acceptance/task.controller.acceptance.ts
+++ b/services/task-service/src/__tests__/acceptance/task.controller.acceptance.ts
@@ -93,6 +93,7 @@ describe('TaskController: Acceptance', () => {
       ...mockTasks[0],
       key: 'test2',
       name: 'test2',
+      externalId: 'processInstanceId2',
     });
   }
 });

--- a/services/task-service/src/__tests__/fixtures/mock-data.ts
+++ b/services/task-service/src/__tests__/fixtures/mock-data.ts
@@ -37,5 +37,6 @@ export const mockTasks: Task[] = [
     severity: TaskSeverity.High,
     type: 'task-1',
     metadata: {},
+    externalId: 'processInstanceId1',
   }),
 ];

--- a/services/task-service/src/models/task.model.ts
+++ b/services/task-service/src/models/task.model.ts
@@ -102,5 +102,5 @@ export class Task<TS = TaskStatus> extends UserModifiableEntity<Task> {
     name: 'external_id',
     type: 'string',
   })
-  externalId: string;
+  externalId?: string;
 }

--- a/services/task-service/src/models/task.model.ts
+++ b/services/task-service/src/models/task.model.ts
@@ -102,5 +102,5 @@ export class Task<TS = TaskStatus> extends UserModifiableEntity<Task> {
     name: 'external_id',
     type: 'string',
   })
-  externalId?: string;
+  externalId: string;
 }

--- a/services/task-service/src/services/camunda.service.ts
+++ b/services/task-service/src/services/camunda.service.ts
@@ -37,6 +37,18 @@ export class CamundaService {
     );
   }
 
+  async deleteProcessInstances(ids: string[]) {
+    return Promise.all(
+      ids.map(id =>
+        this.http.delete(`${this.baseUrl}/process-instance/${id}`, {
+          query: {
+            cascade: true,
+          },
+        }),
+      ),
+    );
+  }
+
   async create<T>(name: string, file: Buffer) {
     const form = new FormData();
     form.append(`${name}.bpmn`, file.toString('utf-8'), {

--- a/services/task-service/src/services/camunda.service.ts
+++ b/services/task-service/src/services/camunda.service.ts
@@ -37,16 +37,18 @@ export class CamundaService {
     );
   }
 
-  async deleteProcessInstances(ids: string[]) {
-    return Promise.all(
-      ids.map(id =>
-        this.http.delete(`${this.baseUrl}/process-instance/${id}`, {
-          query: {
-            cascade: true,
-          },
-        }),
-      ),
-    );
+  async deleteProcessInstances(ids: (string | undefined)[]) {
+    if (ids) {
+      return Promise.all(
+        ids.map(id =>
+          this.http.delete(`${this.baseUrl}/process-instance/${id}`, {
+            query: {
+              cascade: true,
+            },
+          }),
+        ),
+      );
+    }
   }
 
   async create<T>(name: string, file: Buffer) {

--- a/services/task-service/src/services/camunda.service.ts
+++ b/services/task-service/src/services/camunda.service.ts
@@ -44,6 +44,7 @@ export class CamundaService {
           this.http.delete(`${this.baseUrl}/process-instance/${id}`, {
             query: {
               cascade: true,
+              skipCustomListeners: true,
             },
           }),
         ),


### PR DESCRIPTION
## Description

1. Delete process instances on Camunda for deleted tasks.
2. Remove ? to mark externalId as mandatory field.
3. Add Camunda's process instances delete API to delete for process instances from Camunda 

Fixes GH-1972

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [x] Any dependent changes have been merged and published in downstream modules
