### PR TITLE
feat(audit-service): bump major version

### DIFF
--- a/services/audit-service/README.md
+++ b/services/audit-service/README.md
@@ -219,7 +219,7 @@ If `includeArchivedLogs` option is set to `false` (which is default if not provi
 ### Export Logs
 
 This feature is used to export the logs present in Audit Database or the archive storage(eg. AWS.S3). A default loopback filter is accepted based on which logs are exported to the desired location as specified as an excel file(by default) using `AuditLogExportProvider` [here](src/providers/audit-log-export.service.ts).
-The exceljs dependency, used by the `AuditLogExportProvider` for generating Excel files, is optional. Users who wish to utilize this feature should manually install exceljs and bind the AuditLogExportProvider in the application.ts file of your application:
+The exceljs dependency, used by the `AuditLogExportProvider` for generating Excel files, is optional. Users who wish to utilize this feature should manually install exceljs and bind the AuditLogExportProvider in the application.ts of your application:
 
 ```ts
 this.bind(AuditLogExportServiceBindings.EXPORT_AUDIT_LOGS).toProvider(

--- a/services/audit-service/package.json
+++ b/services/audit-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourceloop/audit-service",
   "version": "13.0.0",
-  "description": "Audit logging microservice",
+  "description": "Audit logging Microservice.",
   "keywords": [
     "loopback-extension",
     "loopback"


### PR DESCRIPTION
Auditexportlogprovider and its exceljs deps is made optional by providing separate export path in packagejson file.
(major change)

BREAKING CHANGE:
Auditexportlogprovider and its exceljs deps is made optional by providing separate export path in packagejson file.


GH-2088

## Description
Auditexportlogprovider and its exceljs deps is made optional by providing separate export path in packagejson file.

Fixes #2088 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
