### PR TITLE
fix(core): createdon modifiedon can not be changed via input

### DIFF
--- a/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
+++ b/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
@@ -72,7 +72,7 @@ export abstract class DefaultTransactionalUserModifyRepository<
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
     delete entity.createdOn;
-    delete entity.modifiedOn;
+    entity.modifiedOn = new Date();
     return super.save(entity, options);
   }
 

--- a/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
+++ b/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
@@ -41,8 +41,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
       throw new HttpErrors.Forbidden(AuthErrorKeys.InvalidCredentials);
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
-    delete entity.createdOn;
-    delete entity.modifiedOn;
+    entity.createdOn = new Date();
+    entity.modifiedOn = new Date();
     entity.createdBy = uid;
     entity.modifiedBy = uid;
     return super.create(entity, options);
@@ -58,8 +58,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     entities.forEach(entity => {
       entity.createdBy = uid ?? '';
       entity.modifiedBy = uid ?? '';
-      delete entity.createdOn;
-      delete entity.modifiedOn;
+      entity.createdOn = new Date();
+      entity.modifiedOn = new Date();
     });
     return super.createAll(entities, options);
   }

--- a/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
+++ b/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
@@ -41,6 +41,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
       throw new HttpErrors.Forbidden(AuthErrorKeys.InvalidCredentials);
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
+    delete entity.createdOn;
+    delete entity.modifiedOn;
     entity.createdBy = uid;
     entity.modifiedBy = uid;
     return super.create(entity, options);
@@ -56,6 +58,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     entities.forEach(entity => {
       entity.createdBy = uid ?? '';
       entity.modifiedBy = uid ?? '';
+      delete entity.createdOn;
+      delete entity.modifiedOn;
     });
     return super.createAll(entities, options);
   }
@@ -67,6 +71,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    delete entity.createdOn;
+    delete entity.modifiedOn;
     return super.save(entity, options);
   }
 
@@ -77,6 +83,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    delete entity.createdOn;
+    delete entity.modifiedOn;
     return super.update(entity, options);
   }
 
@@ -92,6 +100,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    delete data.createdOn;
+    delete data.modifiedOn;
     return super.updateAll(data, where, options);
   }
 
@@ -107,6 +117,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    delete data.createdOn;
+    delete data.modifiedOn;
     return super.updateById(id, data, options);
   }
 
@@ -121,6 +133,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    delete data.createdOn;
+    delete data.modifiedOn;
     return super.replaceById(id, data, options);
   }
 }

--- a/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
+++ b/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
@@ -44,6 +44,8 @@ export class DefaultUserModifyCrudRepository<
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.createdBy = uid;
     entity.modifiedBy = uid;
+    delete entity.createdOn;
+    delete entity.modifiedOn;
     return super.create(entity, options);
   }
 
@@ -57,6 +59,8 @@ export class DefaultUserModifyCrudRepository<
     entities.forEach(entity => {
       entity.createdBy = uid ?? '';
       entity.modifiedBy = uid ?? '';
+      delete entity.createdOn;
+      delete entity.modifiedOn;
     });
     return super.createAll(entities, options);
   }
@@ -68,6 +72,8 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    delete entity.createdOn;
+    delete entity.modifiedOn;
     return super.save(entity, options);
   }
 
@@ -78,6 +84,8 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    delete entity.createdOn;
+    delete entity.modifiedOn;
     return super.update(entity, options);
   }
 
@@ -93,6 +101,8 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    delete data.createdOn;
+    delete data.modifiedOn;
     return super.updateAll(data, where, options);
   }
 
@@ -108,6 +118,8 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    delete data.createdOn;
+    delete data.modifiedOn;
     return super.updateById(id, data, options);
   }
   async replaceById(
@@ -121,6 +133,8 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    delete data.createdOn;
+    delete data.modifiedOn;
     return super.replaceById(id, data, options);
   }
 }

--- a/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
+++ b/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
@@ -73,7 +73,7 @@ export class DefaultUserModifyCrudRepository<
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
     delete entity.createdOn;
-    delete entity.modifiedOn;
+    entity.modifiedOn = new Date();
     return super.save(entity, options);
   }
 

--- a/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
+++ b/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
@@ -44,8 +44,8 @@ export class DefaultUserModifyCrudRepository<
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.createdBy = uid;
     entity.modifiedBy = uid;
-    delete entity.createdOn;
-    delete entity.modifiedOn;
+    entity.createdOn = new Date();
+    entity.modifiedOn = new Date();
     return super.create(entity, options);
   }
 
@@ -59,8 +59,8 @@ export class DefaultUserModifyCrudRepository<
     entities.forEach(entity => {
       entity.createdBy = uid ?? '';
       entity.modifiedBy = uid ?? '';
-      delete entity.createdOn;
-      delete entity.modifiedOn;
+      entity.createdOn = new Date();
+      entity.modifiedOn = new Date();
     });
     return super.createAll(entities, options);
   }


### PR DESCRIPTION
gh-2158

## Description

createdon modifiedon can not be changed via input
even if its passed in the input we will delete the fields and update it from db

Fixes #2158 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
