### PR TITLE
feat(core): restrict modification of createdon and modifiedon

### DIFF
--- a/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
+++ b/packages/core/src/repositories/default-transactional-user-modify-repository.base.ts
@@ -16,6 +16,7 @@ import {AuthErrorKeys} from 'loopback4-authentication';
 import {DefaultTransactionSoftCrudRepository} from 'loopback4-soft-delete';
 import {IAuthUserWithPermissions} from '../components';
 import {UserModifiableEntity} from '../models';
+import {RepositoryOverridingOptions} from '../types';
 
 export abstract class DefaultTransactionalUserModifyRepository<
   T extends UserModifiableEntity,
@@ -34,6 +35,8 @@ export abstract class DefaultTransactionalUserModifyRepository<
     super(entityClass, dataSource);
   }
 
+  public overridingOptions?: RepositoryOverridingOptions;
+
   async create(entity: DataObject<T>, options?: Options): Promise<T> {
     let currentUser = await this.getCurrentUser();
     currentUser = currentUser ?? options?.currentUser;
@@ -43,6 +46,10 @@ export abstract class DefaultTransactionalUserModifyRepository<
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.createdBy = uid;
     entity.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      delete entity.createdOn;
+      delete entity.modifiedOn;
+    }
     return super.create(entity, options);
   }
 
@@ -56,6 +63,10 @@ export abstract class DefaultTransactionalUserModifyRepository<
     entities.forEach(entity => {
       entity.createdBy = uid ?? '';
       entity.modifiedBy = uid ?? '';
+      if (this.overridingOptions?.restrictDateModification) {
+        delete entity.createdOn;
+        delete entity.modifiedOn;
+      }
     });
     return super.createAll(entities, options);
   }
@@ -67,6 +78,10 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      delete entity.createdOn;
+      delete entity.modifiedOn;
+    }
     return super.save(entity, options);
   }
 
@@ -77,6 +92,11 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete entity.modifiedOn;
+    }
     return super.update(entity, options);
   }
 
@@ -92,6 +112,11 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete data.modifiedOn;
+    }
     return super.updateAll(data, where, options);
   }
 
@@ -107,6 +132,11 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete data.modifiedOn;
+    }
     return super.updateById(id, data, options);
   }
 
@@ -121,6 +151,11 @@ export abstract class DefaultTransactionalUserModifyRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete data.modifiedOn;
+    }
     return super.replaceById(id, data, options);
   }
 }

--- a/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
+++ b/packages/core/src/repositories/default-user-modify-crud.repository.base.ts
@@ -17,6 +17,7 @@ import {SoftCrudRepository} from 'loopback4-soft-delete';
 
 import {IAuthUserWithPermissions} from '../components';
 import {UserModifiableEntity} from '../models';
+import {RepositoryOverridingOptions} from '../types';
 
 export class DefaultUserModifyCrudRepository<
   T extends UserModifiableEntity,
@@ -34,6 +35,7 @@ export class DefaultUserModifyCrudRepository<
   ) {
     super(entityClass, dataSource);
   }
+  public overridingOptions?: RepositoryOverridingOptions;
 
   async create(entity: DataObject<T>, options?: Options): Promise<T> {
     let currentUser = await this.getCurrentUser();
@@ -44,6 +46,10 @@ export class DefaultUserModifyCrudRepository<
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.createdBy = uid;
     entity.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      delete entity.createdOn;
+      delete entity.modifiedOn;
+    }
     return super.create(entity, options);
   }
 
@@ -57,6 +63,10 @@ export class DefaultUserModifyCrudRepository<
     entities.forEach(entity => {
       entity.createdBy = uid ?? '';
       entity.modifiedBy = uid ?? '';
+      if (this.overridingOptions?.restrictDateModification) {
+        delete entity.createdOn;
+        delete entity.modifiedOn;
+      }
     });
     return super.createAll(entities, options);
   }
@@ -68,6 +78,10 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      delete entity.createdOn;
+      delete entity.modifiedOn;
+    }
     return super.save(entity, options);
   }
 
@@ -78,6 +92,11 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     entity.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete entity.modifiedOn;
+    }
     return super.update(entity, options);
   }
 
@@ -93,6 +112,11 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete data.modifiedOn;
+    }
     return super.updateAll(data, where, options);
   }
 
@@ -108,6 +132,11 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete data.modifiedOn;
+    }
     return super.updateById(id, data, options);
   }
   async replaceById(
@@ -121,6 +150,11 @@ export class DefaultUserModifyCrudRepository<
     }
     const uid = currentUser?.userTenantId ?? currentUser?.id;
     data.modifiedBy = uid;
+    if (this.overridingOptions?.restrictDateModification) {
+      /**not deleting the createdOn as it can be a use case where
+       * we want to update the modifiedOn but not the createdOn */
+      delete data.modifiedOn;
+    }
     return super.replaceById(id, data, options);
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,13 @@ export interface IServiceConfig {
   useCustomSequence: boolean;
   useSequelize?: boolean;
 }
-
+/**This type is used to override the default behaviour of our repo classes */
+export interface RepositoryOverridingOptions {
+  /**restricts user to pass createdOn and modifiedOn fields in the request body
+   * and only current date will be set in the database */
+  restrictDateModification: boolean;
+  [property: string]: any; //NOSONAR
+}
 export type OASPathDefinition = AnyObject;
 
 export interface CoreConfig {


### PR DESCRIPTION
gh-2158

## Description

restrict modification of createdon and modifiedon
with this the existing functionality will be same 
all the user needs to do is pass on the property to restrict otherwise it will allow you to pass createdOn and modifiedOn via API as well(current behaviour)

Fixes #2158

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added it to an existing repository and tested it 

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
