### PR TITLE
fix(bpmn-service): add new worker key to handle OptimisticLockingException error

### DIFF
--- a/services/bpmn-service/src/__tests__/unit/register-worker.unit.ts
+++ b/services/bpmn-service/src/__tests__/unit/register-worker.unit.ts
@@ -34,13 +34,13 @@ describe('RegisterWorker unit', () => {
           command: task1,
           running: false,
           topic: 'topic1',
-          inProgress: false,
+          isInProgress: false,
         },
         {
           command: task2,
           running: false,
           topic: 'topic2',
-          inProgress: false,
+          isInProgress: false,
         },
       ],
       workflow2: [
@@ -48,13 +48,13 @@ describe('RegisterWorker unit', () => {
           command: task3,
           running: false,
           topic: 'topic3',
-          inProgress: false,
+          isInProgress: false,
         },
         {
           command: task4,
           running: false,
           topic: 'topic4',
-          inProgress: false,
+          isInProgress: false,
         },
       ],
     };

--- a/services/bpmn-service/src/__tests__/unit/register-worker.unit.ts
+++ b/services/bpmn-service/src/__tests__/unit/register-worker.unit.ts
@@ -2,10 +2,10 @@
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
-import {WorkerRegisterFnProvider} from '../../providers/register-worker.service';
-import {expect} from '@loopback/testlab';
-import {BPMTask, WorkerMap} from '../../types';
 import {AnyObject} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import {WorkerRegisterFnProvider} from '../../providers/register-worker.service';
+import {BPMTask, WorkerMap} from '../../types';
 
 describe('RegisterWorker unit', () => {
   let map: WorkerMap = {};
@@ -34,11 +34,13 @@ describe('RegisterWorker unit', () => {
           command: task1,
           running: false,
           topic: 'topic1',
+          inProgress: false,
         },
         {
           command: task2,
           running: false,
           topic: 'topic2',
+          inProgress: false,
         },
       ],
       workflow2: [
@@ -46,11 +48,13 @@ describe('RegisterWorker unit', () => {
           command: task3,
           running: false,
           topic: 'topic3',
+          inProgress: false,
         },
         {
           command: task4,
           running: false,
           topic: 'topic4',
+          inProgress: false,
         },
       ],
     };

--- a/services/bpmn-service/src/__tests__/unit/worker-implementation.provider.unit.ts
+++ b/services/bpmn-service/src/__tests__/unit/worker-implementation.provider.unit.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2023 Sourcefuse Technologies
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+import {AnyObject} from '@loopback/repository';
+import {expect} from '@loopback/testlab';
+import {ICommand, ILogger} from '@sourceloop/core';
+import {Client} from 'camunda-external-task-client-js';
+import sinon from 'sinon';
+import {WorkerImplementationProvider} from '../../providers/worker-implementation.provider';
+import {BPMTask, IWorkflowServiceConfig, WorkerNameCmdPair} from '../../types';
+
+describe('WorkerImplementationProvider Unit Tests', () => {
+  let worker: WorkerNameCmdPair;
+  let provider: WorkerImplementationProvider;
+  let mockClient: sinon.SinonStubbedInstance<Client>;
+  let mockLogger: sinon.SinonStubbedInstance<ILogger>;
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    // Mock Logger
+    mockLogger = {
+      info: sinon.stub(),
+      error: sinon.stub(),
+      warn: sinon.stub(),
+      debug: sinon.stub(),
+    } as unknown as sinon.SinonStubbedInstance<ILogger>;
+
+    // Mock Workflow Service Config
+    const config: IWorkflowServiceConfig = {
+      useCustomSequence: true,
+      workflowEngineBaseUrl: 'http://localhost:8080',
+    };
+
+    // Mock Camunda Client
+    mockClient = sinon.createStubInstance(Client);
+    sinon.stub(Client.prototype, 'subscribe').callsFake((_topic, callback) => {
+      callback({
+        task: {
+          variables: {
+            get: sinon.stub(),
+            getTyped: sinon.stub(),
+            getAll: sinon.stub(),
+            getAllTyped: sinon.stub(),
+            set: sinon.stub(),
+            setTyped: sinon.stub(),
+            setAll: sinon.stub(),
+            setAllTyped: sinon.stub(),
+          },
+        },
+        taskService: {
+          complete: sinon.stub(),
+          handleFailure: sinon.stub(),
+          handleBpmnError: sinon.stub(),
+          extendLock: sinon.stub(),
+          unlock: sinon.stub(),
+        },
+      });
+      return {unsubscribe: sinon.stub()};
+    });
+
+    // Use fake timers to control setTimeout/setInterval
+    clock = sinon.useFakeTimers();
+
+    provider = new WorkerImplementationProvider(config, mockLogger);
+
+    const mockCommand: ICommand = {
+      parameters: {},
+      execute: sinon.stub().resolves({}), // Mock execute() to return a resolved promise
+    };
+
+    // Initialize Worker
+    worker = {
+      topic: 'test-topic',
+      command: new BPMTask<AnyObject, AnyObject>(mockCommand),
+      running: false,
+      isInProgress: false,
+    };
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+  });
+
+  it('should initialize worker with isInProgress as false', async () => {
+    const implementationFn = provider.value();
+    await implementationFn(worker);
+    expect(worker.isInProgress).to.be.false();
+  });
+
+  it('should set isInProgress to true when processing starts', async () => {
+    const implementationFn = provider.value();
+
+    // Ensure `worker.isInProgress` starts as false
+    expect(worker.isInProgress).to.be.false();
+
+    // Modify existing stub instead of re-stubbing
+    (worker.command.command.execute as sinon.SinonStub).callsFake(async () => {
+      // verify isInProgress is true during worker execution flow
+      expect(worker.isInProgress).to.be.true();
+      return {};
+    });
+
+    await implementationFn(worker);
+  });
+
+  it('should return early if worker is already in progress', async () => {
+    worker.isInProgress = true;
+    provider.client = mockClient as unknown as Client;
+
+    const implementationFn = provider.value();
+    await implementationFn(worker);
+
+    const operationStub = sinon.stub(worker.command, 'operation');
+    await implementationFn(worker);
+
+    expect(operationStub.called).to.be.false();
+  });
+
+  it('should set isInProgress to false when task completes', async () => {
+    const implementationFn = provider.value();
+    await implementationFn(worker);
+
+    // Properly stub the 'operation' method
+    const operationStub = sinon.stub(worker.command, 'operation');
+
+    // Simulate task completion by invoking the callback with an empty object
+    operationStub.callsFake((_data, done) => {
+      if (done) done({});
+    });
+
+    expect(worker.isInProgress).to.be.false();
+
+    // Restore the stub after the test
+    operationStub.restore();
+  });
+
+  it('should set isInProgress to false if an error occurs during polling', async () => {
+    sinon.restore();
+    const onStub = sinon
+      .stub(mockClient, 'on')
+      .callsArgWith(1, new Error('Test Poll Error'));
+
+    const implementationFn = provider.value();
+    await implementationFn(worker);
+
+    // Simulate poll error
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (provider.client as any).emit(
+      'poll:error',
+      new Error('Simulated Polling Error'),
+    );
+
+    expect(worker.isInProgress).to.be.false();
+    expect(worker.running).to.be.false();
+
+    onStub.restore();
+  });
+});

--- a/services/bpmn-service/src/__tests__/unit/worker-implementation.provider.unit.ts
+++ b/services/bpmn-service/src/__tests__/unit/worker-implementation.provider.unit.ts
@@ -92,9 +92,6 @@ describe('WorkerImplementationProvider Unit Tests', () => {
   it('should set isInProgress to true when processing starts', async () => {
     const implementationFn = provider.value();
 
-    // Ensure `worker.isInProgress` starts as false
-    expect(worker.isInProgress).to.be.false();
-
     // Modify existing stub instead of re-stubbing
     (worker.command.command.execute as sinon.SinonStub).callsFake(async () => {
       // verify isInProgress is true during worker execution flow

--- a/services/bpmn-service/src/providers/register-worker.service.ts
+++ b/services/bpmn-service/src/providers/register-worker.service.ts
@@ -25,11 +25,11 @@ export class WorkerRegisterFnProvider implements Provider<WorkerRegisterFn> {
           topic,
           command,
           running: false,
-          inProgress: false,
+          isInProgress: false,
         });
       } else {
         workerMap[workflowName] = [
-          {topic, command, running: false, inProgress: false},
+          {topic, command, running: false, isInProgress: false},
         ];
         this.workerMapSetter(workerMap);
       }

--- a/services/bpmn-service/src/providers/register-worker.service.ts
+++ b/services/bpmn-service/src/providers/register-worker.service.ts
@@ -21,9 +21,16 @@ export class WorkerRegisterFnProvider implements Provider<WorkerRegisterFn> {
         workerMap = {};
       }
       if (workerMap[workflowName]) {
-        workerMap[workflowName].push({topic, command, running: false});
+        workerMap[workflowName].push({
+          topic,
+          command,
+          running: false,
+          inProgress: false,
+        });
       } else {
-        workerMap[workflowName] = [{topic, command, running: false}];
+        workerMap[workflowName] = [
+          {topic, command, running: false, inProgress: false},
+        ];
         this.workerMapSetter(workerMap);
       }
     };

--- a/services/bpmn-service/src/providers/worker-implementation.provider.ts
+++ b/services/bpmn-service/src/providers/worker-implementation.provider.ts
@@ -31,27 +31,27 @@ export class WorkerImplementationProvider
   value(): WorkerImplementationFn {
     return async worker => {
       if (this.client) {
-        worker.inProgress = false;
+        worker.isInProgress = false;
         worker.running = true;
         const subscription = this.client.subscribe(
           worker.topic,
           ({task, taskService}) => {
-            if (worker.inProgress) return;
-            worker.inProgress = true;
+            if (worker.isInProgress) return;
+            worker.isInProgress = true;
             worker.command.operation(
               {task, taskService},
               (result: AnyObject) => {
                 if (result) {
                   this.ilogger.info(`Worker task completed - ${worker.topic}`);
                 }
-                worker.inProgress = false;
+                worker.isInProgress = false;
               },
             );
           },
         );
         this.client.on('poll:error', () => {
           worker.running = false;
-          worker.inProgress = false;
+          worker.isInProgress = false;
           subscription.unsubscribe();
         });
       } else {

--- a/services/bpmn-service/src/types/types.ts
+++ b/services/bpmn-service/src/types/types.ts
@@ -57,7 +57,7 @@ export type WorkerNameCmdPair<T = AnyObject, R = AnyObject> = {
   topic: string;
   command: BPMTask<T, R>;
   running: boolean;
-  inProgress: boolean;
+  isInProgress: boolean;
 };
 
 export type WorkerImplementationFn<T = AnyObject, R = AnyObject> = (

--- a/services/bpmn-service/src/types/types.ts
+++ b/services/bpmn-service/src/types/types.ts
@@ -4,8 +4,8 @@
 // https://opensource.org/licenses/MIT
 import {AnyObject} from '@loopback/repository';
 import {IServiceConfig} from '@sourceloop/core';
+import {Workflow, WorkflowDto, WorkflowVersion} from '../models';
 import {BPMTask} from './bpm-task';
-import {Workflow, WorkflowVersion, WorkflowDto} from '../models';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface ICommand {
@@ -57,6 +57,7 @@ export type WorkerNameCmdPair<T = AnyObject, R = AnyObject> = {
   topic: string;
   command: BPMTask<T, R>;
   running: boolean;
+  inProgress: boolean;
 };
 
 export type WorkerImplementationFn<T = AnyObject, R = AnyObject> = (

--- a/services/task-service/src/lifecycle-observers/command.observer.ts
+++ b/services/task-service/src/lifecycle-observers/command.observer.ts
@@ -34,7 +34,7 @@ export class CommandObserver implements LifeCycleObserver {
         topic: command.topic,
         command: new BPMTask(command),
         running: false,
-        inProgress: false,
+        isInProgress: false,
       });
     }
     this.logger.debug('Commands registered');

--- a/services/task-service/src/lifecycle-observers/command.observer.ts
+++ b/services/task-service/src/lifecycle-observers/command.observer.ts
@@ -34,6 +34,7 @@ export class CommandObserver implements LifeCycleObserver {
         topic: command.topic,
         command: new BPMTask(command),
         running: false,
+        inProgress: false,
       });
     }
     this.logger.debug('Commands registered');


### PR DESCRIPTION
## Description

add new worker key inProgress to handle OptimisticLockingException error.
when the worker id is generated for a topic in bpmn serivice, the same id is being picked after some time and the command tries to make it complete again. that is causing OptimisticLockingException error.
on introducing new key inProgress in the worker, it will ensure that the job will be picked only once if inProgress is true.


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Ran test cases and updated the failing test cases beacuse of the new changes.
- Ran bpmn package build locally in my service to verify the changes.

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide