### PR TITLE
fix(file-utils): remove direct export of clamav to avoid direct dep

### DIFF
--- a/packages/file-utils/src/__tests__/integration/file-uploader.integration.ts
+++ b/packages/file-utils/src/__tests__/integration/file-uploader.integration.ts
@@ -259,18 +259,22 @@ describe('FileUploaderComponent', () => {
           )
           .field('name', 'testName')
           .expect(400);
-        expect(response.body.error.message).to.equal('Infected file: test.txt');
+        expect(response.body.error.message).to.equal(
+          'File is infected - test.txt',
+        );
       });
       it('should parse a multipart request and apply all the validators', async () => {
-        // let response = await client
-        //   .post('/multiple')
-        //   .attach(
-        //     'files',
-        //     './src/__tests__/integration/fixtures/dummy-files/test.txt',
-        //   )
-        //   .field('name', 'testName')
-        //   .expect(400);
-        // expect(response.body.error.message).to.equal('Infected file: test.txt');
+        const response = await client
+          .post('/multiple')
+          .attach(
+            'files',
+            './src/__tests__/integration/fixtures/dummy-files/test.txt',
+          )
+          .field('name', 'testName')
+          .expect(400);
+        expect(response.body.error.message).to.equal(
+          'File is infected - test.txt',
+        );
 
         await client
           .post('/multiple')

--- a/packages/file-utils/src/__tests__/integration/file-uploader.integration.ts
+++ b/packages/file-utils/src/__tests__/integration/file-uploader.integration.ts
@@ -1,6 +1,7 @@
 import {DataObject} from '@loopback/repository';
 import {Client, expect, sinon} from '@loopback/testlab';
 import {FileUtilBindings} from '../..';
+import {MultipartModel} from './fixtures';
 import {ParentWithFile} from './fixtures/controllers/parent.controller';
 import {MulterConfigService} from './fixtures/services/multer-config.service';
 import {TestApp} from './fixtures/test.application';
@@ -10,7 +11,10 @@ describe('FileUploaderComponent', () => {
   let app: TestApp;
   let client: Client;
   let receiverStub: {
-    receive: sinon.SinonStub<[DataObject<ParentWithFile>], void>;
+    receive: sinon.SinonStub<
+      [DataObject<ParentWithFile & MultipartModel>],
+      void
+    >;
   };
   before('setupApplication', async () => {
     ({app, client} = await setupApplication());
@@ -256,6 +260,30 @@ describe('FileUploaderComponent', () => {
           .field('name', 'testName')
           .expect(400);
         expect(response.body.error.message).to.equal('Infected file: test.txt');
+      });
+      it('should parse a multipart request and apply all the validators', async () => {
+        // let response = await client
+        //   .post('/multiple')
+        //   .attach(
+        //     'files',
+        //     './src/__tests__/integration/fixtures/dummy-files/test.txt',
+        //   )
+        //   .field('name', 'testName')
+        //   .expect(400);
+        // expect(response.body.error.message).to.equal('Infected file: test.txt');
+
+        await client
+          .post('/multiple')
+          .attach(
+            'files',
+            './src/__tests__/integration/fixtures/dummy-files/test.png',
+          )
+          .field('name', 'testName')
+          .expect(204);
+
+        expect(
+          receiverStub.receive.getCalls()[0].args[0].files?.size,
+        ).deepEqual(1916);
       });
     });
   });

--- a/packages/file-utils/src/__tests__/integration/fixtures/controllers/multipart.controller.ts
+++ b/packages/file-utils/src/__tests__/integration/fixtures/controllers/multipart.controller.ts
@@ -1,0 +1,24 @@
+import {inject} from '@loopback/core';
+import {getModelSchemaRef, post, response} from '@loopback/rest';
+import {multipartRequestBody} from '../../../../decorators';
+import {MultipartModel} from '../models';
+
+export class MultipartController {
+  constructor(
+    @inject('services.ReceiverStub')
+    private readonly receiverStub: {
+      receive: (data: MultipartModel) => void;
+    },
+  ) {}
+  @post(`/multiple`)
+  @response(200, {
+    description: 'Multipart model instance',
+    content: {'application/json': {schema: getModelSchemaRef(MultipartModel)}},
+  })
+  async createMultiple(
+    @multipartRequestBody(MultipartModel)
+    data: MultipartModel,
+  ): Promise<void> {
+    this.receiverStub.receive(data);
+  }
+}

--- a/packages/file-utils/src/__tests__/integration/fixtures/models/index.ts
+++ b/packages/file-utils/src/__tests__/integration/fixtures/models/index.ts
@@ -1,3 +1,4 @@
+export * from './multipart.model';
 export * from './multiple-files.model';
 export * from './parent-with-config.model';
 export * from './parent.model';

--- a/packages/file-utils/src/__tests__/integration/fixtures/models/multipart.model.ts
+++ b/packages/file-utils/src/__tests__/integration/fixtures/models/multipart.model.ts
@@ -1,5 +1,6 @@
 import {Entity, model} from '@loopback/repository';
 import {fileProperty} from '../../../../decorators/file-property.decorator';
+import {FileTypeValidator} from '../../../../services';
 import {ClamAVValidator} from '../../../../sub-packages';
 
 @model()
@@ -7,7 +8,7 @@ export class MultipartModel extends Entity {
   @fileProperty({
     type: 'array',
     itemType: 'string',
-    validators: [ClamAVValidator],
+    validators: [FileTypeValidator, ClamAVValidator],
     extensions: ['.pdf', '.txt', '.png'],
   })
   files: Express.Multer.File;

--- a/packages/file-utils/src/__tests__/integration/fixtures/models/multipart.model.ts
+++ b/packages/file-utils/src/__tests__/integration/fixtures/models/multipart.model.ts
@@ -1,0 +1,18 @@
+import {Entity, model} from '@loopback/repository';
+import {fileProperty} from '../../../../decorators/file-property.decorator';
+import {ClamAVValidator} from '../../../../sub-packages';
+
+@model()
+export class MultipartModel extends Entity {
+  @fileProperty({
+    type: 'array',
+    itemType: 'string',
+    validators: [ClamAVValidator],
+    extensions: ['.pdf', '.txt', '.png'],
+  })
+  files: Express.Multer.File;
+
+  constructor(data?: Partial<MultipartModel>) {
+    super(data);
+  }
+}

--- a/packages/file-utils/src/__tests__/integration/fixtures/test.application.ts
+++ b/packages/file-utils/src/__tests__/integration/fixtures/test.application.ts
@@ -5,7 +5,7 @@ import {RestApplication} from '@loopback/rest';
 import {ServiceMixin} from '@loopback/service-proxy';
 import {AWSS3Bindings} from 'loopback4-s3';
 import {FileUtilComponent} from '../../../component';
-import {ClamAVValidator} from '../../../services';
+import {ClamAVValidator} from '../../../sub-packages';
 import {Parent} from './models';
 
 export class TestApp extends BootMixin(

--- a/packages/file-utils/src/constant.ts
+++ b/packages/file-utils/src/constant.ts
@@ -1,3 +1,4 @@
+import {ReferenceObject, SchemaObject} from '@loopback/rest';
 import multer from 'multer';
 import {
   IFileRequestMetadata,
@@ -34,4 +35,10 @@ export function getUploadConfig(
   return uploadOptions.definition
     ? (uploadOptions as IFileRequestMetadata<never>)
     : metadata;
+}
+
+export function isSchemaObject(
+  ob: SchemaObject | ReferenceObject | undefined,
+): ob is SchemaObject {
+  return (ob as SchemaObject)?.type !== undefined;
 }

--- a/packages/file-utils/src/constant.ts
+++ b/packages/file-utils/src/constant.ts
@@ -42,3 +42,7 @@ export function isSchemaObject(
 ): ob is SchemaObject {
   return (ob as SchemaObject)?.type !== undefined;
 }
+
+export function isFile(file: Partial<File>) {
+  return file instanceof File;
+}

--- a/packages/file-utils/src/decorators/file-property.decorator.ts
+++ b/packages/file-utils/src/decorators/file-property.decorator.ts
@@ -11,5 +11,5 @@ import {IFileRequestMetadata} from '../types';
 export function fileProperty<T>(
   definition: Partial<PropertyDefinition & IFileRequestMetadata<T>>,
 ) {
-  return property(definition);
+  return property({...definition, file: true});
 }

--- a/packages/file-utils/src/decorators/multipart-request-body.decorator.ts
+++ b/packages/file-utils/src/decorators/multipart-request-body.decorator.ts
@@ -4,6 +4,7 @@ import {cloneDeep} from 'lodash';
 
 import {AnyObject, Entity} from '@loopback/repository';
 import {ModelConstructor} from '@sourceloop/core';
+import {isSchemaObject} from '../constant';
 import {FileUtilBindings} from '../keys';
 import {IModelWithFileMetadata} from '../types';
 /**
@@ -49,12 +50,7 @@ export function multipartRequestBody<S extends Entity, T = AnyObject>(
   return function (target: object, member: string, index: number) {
     const defaultSchema: SchemaObject = {
       type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          format: 'binary',
-        },
-      },
+      properties: {},
     };
     const schema = getJsonSchema(model) as SchemaObject;
     const fileFields = Object.entries(model.definition.properties)
@@ -63,12 +59,20 @@ export function multipartRequestBody<S extends Entity, T = AnyObject>(
     if (schema && fileFields.length) {
       const newSchema = cloneDeep(schema);
       for (const field of fileFields) {
-        if (newSchema.properties?.[field]) {
-          (newSchema.properties?.[field] as SchemaObject).format = 'binary';
+        const fieldSchema = newSchema.properties?.[field];
+        if (isSchemaObject(fieldSchema)) {
+          if (fieldSchema.type === 'array') {
+            fieldSchema.items = {
+              ...fieldSchema.items,
+              format: 'binary',
+            };
+          } else {
+            fieldSchema.format = 'binary';
+          }
         }
       }
       defaultSchema.properties = {
-        ...defaultSchema.properties,
+        ...schema.properties,
         ...newSchema.properties,
       };
     }

--- a/packages/file-utils/src/services/multer-storage.provider.ts
+++ b/packages/file-utils/src/services/multer-storage.provider.ts
@@ -38,7 +38,16 @@ export class MulterStorageProvider implements Provider<multer.StorageEngine> {
                     .then(results => {
                       const firstError = results.find(r => r);
                       if (firstError) {
-                        cb(new HttpErrors.BadRequest(firstError));
+                        if (info) {
+                          // need to do this casting because of wrong typings
+                          storage._removeFile(
+                            req,
+                            info as Express.Multer.File,
+                            err => {
+                              cb(new HttpErrors.BadRequest(firstError));
+                            },
+                          );
+                        }
                       } else {
                         cb(undefined, info);
                       }

--- a/packages/file-utils/src/services/validators/file-name-validator.provider.ts
+++ b/packages/file-utils/src/services/validators/file-name-validator.provider.ts
@@ -3,14 +3,13 @@ import {HttpErrors} from '@loopback/rest';
 import path from 'path';
 import {NAME_REGEX} from '../../constant';
 import {fileValidator} from '../../decorators';
-import {File, IFileValidator} from '../../types';
+import {File, IFileValidator, ValidatorOutput} from '../../types';
 
 @fileValidator()
 export class FileNameValidator implements IFileValidator {
   constructor() {}
-  async validate(file: File): Promise<File> {
-    await this._validateFileName(file);
-    return file;
+  async validate(file: File): Promise<ValidatorOutput> {
+    return this._validateFileName(file);
   }
 
   private async _validateFileName(file: Express.Multer.File) {
@@ -23,6 +22,6 @@ export class FileNameValidator implements IFileValidator {
         'File name should not contain special characters',
       );
     }
-    return file;
+    return {file};
   }
 }

--- a/packages/file-utils/src/services/validators/file-name-validator.provider.ts
+++ b/packages/file-utils/src/services/validators/file-name-validator.provider.ts
@@ -1,14 +1,14 @@
 import {HttpErrors} from '@loopback/rest';
 
-import {fileValidator} from '../../decorators';
-import {IFileValidator, File} from '../../types';
 import path from 'path';
 import {NAME_REGEX} from '../../constant';
+import {fileValidator} from '../../decorators';
+import {File, IFileValidator} from '../../types';
 
 @fileValidator()
 export class FileNameValidator implements IFileValidator {
   constructor() {}
-  async validate(file: Express.Multer.File): Promise<File> {
+  async validate(file: File): Promise<File> {
     await this._validateFileName(file);
     return file;
   }

--- a/packages/file-utils/src/services/validators/file-type-validator.provider.ts
+++ b/packages/file-utils/src/services/validators/file-type-validator.provider.ts
@@ -1,11 +1,11 @@
 import {inject} from '@loopback/core';
 import {HttpErrors} from '@loopback/rest';
-import {fromStream} from 'file-type';
 
+import {fromBuffer} from 'file-type';
 import {PassThrough} from 'stream';
 import {fileValidator} from '../../decorators';
 import {FileUtilBindings} from '../../keys';
-import {File, IFileValidator, MulterConfig} from '../../types';
+import {File, IFileValidator, MulterConfig, ValidatorOutput} from '../../types';
 
 @fileValidator()
 export class FileTypeValidator implements IFileValidator {
@@ -15,7 +15,7 @@ export class FileTypeValidator implements IFileValidator {
     @inject(FileUtilBindings.MulterConfig, {optional: true})
     private readonly uploadOptionsGetter: MulterConfig,
   ) {}
-  async validate(file: File): Promise<File> {
+  async validate(file: File): Promise<ValidatorOutput> {
     const ext = `.${file.originalname.split('.').pop() ?? ''}`;
 
     if (this.textFileTypes.includes(ext)) {
@@ -23,7 +23,7 @@ export class FileTypeValidator implements IFileValidator {
     } else {
       return this._validateBinaryFile(file, ext);
     }
-    return file;
+    return {file};
   }
 
   private async _validateTextFile(
@@ -48,26 +48,40 @@ export class FileTypeValidator implements IFileValidator {
     );
 
     const cloneStream = new PassThrough();
-    file.stream.pipe(cloneStream);
-    try {
-      const trueType = await fromStream(cloneStream);
-      /**
-       * Trutype gives `jpg` and we maintain whitelist as `['.jpg']`
-       */
-      let ext: string | undefined = trueType?.ext;
-      if (ext && !ext.startsWith('.')) {
-        ext = `.${ext}`;
-      }
+    const waiter = new Promise<string | null>((resolve, reject) => {
+      file.stream.once('data', chunk => {
+        cloneStream.write(chunk);
+        file.stream.pipe(cloneStream);
+        fromBuffer(chunk)
+          .then(trueType => {
+            /**
+             * Trutype gives `jpg` and we maintain whitelist as `['.jpg']`
+             */
+            let ext: string | undefined = trueType?.ext;
+            if (ext && !ext.startsWith('.')) {
+              ext = `.${ext}`;
+            }
 
-      if (validExtensions) {
-        if (!ext || !validExtensions.includes(ext) || !file.mimetype) {
-          throw new HttpErrors.BadRequest(`File type not allowed: ${ext}`);
-        }
-      }
-      return file;
-    } catch (error) {
-      cloneStream.destroy();
-      throw error;
-    }
+            if (validExtensions) {
+              if (!ext || !validExtensions.includes(ext) || !file.mimetype) {
+                resolve(`File type not allowed: ${ext}`);
+                return;
+              }
+            }
+            resolve(null);
+          })
+          .catch(err => {
+            resolve(err.message);
+          });
+      });
+    });
+
+    return {
+      file: {
+        ...file,
+        stream: cloneStream,
+      },
+      waiter,
+    };
   }
 }

--- a/packages/file-utils/src/services/validators/index.ts
+++ b/packages/file-utils/src/services/validators/index.ts
@@ -1,3 +1,2 @@
-export * from '../../sub-packages/clamav/validators/clamav-validator.provider';
 export * from './file-name-validator.provider';
 export * from './file-type-validator.provider';

--- a/packages/file-utils/src/sub-packages/clamav/validators/clamav-validator.provider.ts
+++ b/packages/file-utils/src/sub-packages/clamav/validators/clamav-validator.provider.ts
@@ -3,10 +3,10 @@ import NodeClam from 'clamscan';
 import {PassThrough} from 'stream';
 import {DEFAULT_CLAMAV_PORT} from '../../../constant';
 import {fileValidator} from '../../../decorators';
-import {File, IFileValidator} from '../../../types';
+import {File, IFileValidator, ValidatorOutput} from '../../../types';
 @fileValidator()
 export class ClamAVValidator implements IFileValidator {
-  async validate(file: File): Promise<File> {
+  async validate(file: File): Promise<ValidatorOutput> {
     if (!process.env.CLAMAV_HOST) {
       throw HttpErrors.InternalServerError('Host not configured');
     }
@@ -16,20 +16,28 @@ export class ClamAVValidator implements IFileValidator {
         port: Number(process.env.CLAMAV_PORT ?? DEFAULT_CLAMAV_PORT),
       },
     });
-    const cloneStream = new PassThrough();
-    file.stream.pipe(cloneStream);
-    const cleanup = () => {
-      cloneStream.destroy();
+    const pass = clamd.passthrough();
+    const newTarget = new PassThrough();
+    file.stream.pipe(pass).pipe(newTarget);
+    const waiter = new Promise<string | null>((resolve, reject) => {
+      pass.on('error', err => {
+        resolve(err.message);
+      });
+      pass.on('scan-complete', result => {
+        if (result.isInfected) {
+          resolve(`File is infected - ${file.originalname}`);
+        } else {
+          resolve(null);
+        }
+      });
+    });
+
+    return {
+      file: {
+        ...file,
+        stream: newTarget,
+      },
+      waiter,
     };
-    try {
-      const result = await clamd.scanStream(cloneStream);
-      if (result.isInfected) {
-        throw new HttpErrors.BadRequest(`Infected file: ${file.originalname}`);
-      }
-    } catch (err) {
-      cleanup();
-      throw err;
-    }
-    return file;
   }
 }

--- a/packages/file-utils/src/sub-packages/clamav/validators/clamav-validator.provider.ts
+++ b/packages/file-utils/src/sub-packages/clamav/validators/clamav-validator.provider.ts
@@ -18,11 +18,8 @@ export class ClamAVValidator implements IFileValidator {
     });
     const cloneStream = new PassThrough();
     file.stream.pipe(cloneStream);
-    const saveStream = new PassThrough();
-    file.stream.pipe(saveStream);
     const cleanup = () => {
       cloneStream.destroy();
-      saveStream.destroy();
     };
     try {
       const result = await clamd.scanStream(cloneStream);
@@ -33,9 +30,6 @@ export class ClamAVValidator implements IFileValidator {
       cleanup();
       throw err;
     }
-    return {
-      ...file,
-      stream: saveStream,
-    };
+    return file;
   }
 }

--- a/packages/file-utils/src/types.ts
+++ b/packages/file-utils/src/types.ts
@@ -78,8 +78,18 @@ export type S3StorageOptions = {
   bucket: string;
 };
 
+export type ValidationResult = {
+  file: File;
+  waiters: Promise<string | null>[];
+};
+
+export type ValidatorOutput = {
+  file: File;
+  waiter?: Promise<string | null>;
+};
+
 export interface IFileValidator {
-  validate(file: File): Promise<File>;
+  validate(file: File): Promise<ValidatorOutput>;
 }
 
 export type FileValidatorWithConstructor = IFileValidator & {


### PR DESCRIPTION
## Description

- remove direct export of clamav to avoid direct dependency on clamav to avoid making it a required dependency
- it can now be used only through the sub-package
- better handling of the multipart request schema for openapi-spec
- improved stream handling slightly, but there is still scope for improvement 
- remove file on error in any of the validators

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
