### PR TITLE
fix(cache): remove uninvalidate as it can undo invalidation in case of subsequent get

### DIFF
--- a/packages/cache/src/__tests__/acceptance/cache-repository.mixin.acceptance.ts
+++ b/packages/cache/src/__tests__/acceptance/cache-repository.mixin.acceptance.ts
@@ -11,7 +11,7 @@ import {setupEnv} from '../helpers';
 import {repoTestBuilder} from '../helpers/test-builder';
 
 dotenv.config();
-const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_TIMEOUT = 15000;
 
 describe('CachedRepository: Acceptance', () => {
   let app: TestApp;
@@ -33,6 +33,8 @@ describe('CachedRepository: Acceptance', () => {
     if (!process.env.REDIS_HOST || !process.env.REDIS_PORT) {
       // eslint-disable-next-line @typescript-eslint/no-invalid-this
       this.skip();
+    } else {
+      mochaContext.timeout(DEFAULT_TIMEOUT);
     }
   });
   beforeEach(async () => {
@@ -87,11 +89,6 @@ describe('CachedRepository: Acceptance', () => {
     describe(testSuite.title, () => {
       testSuite.tests.forEach(test => {
         it(test.title, async function () {
-          if (test.timeout) {
-            mochaContext.timeout(test.timeout);
-          } else {
-            mochaContext.timeout(DEFAULT_TIMEOUT);
-          }
           await test.test(
             repo,
             mockData,

--- a/packages/cache/src/__tests__/fixtures/models/index.ts
+++ b/packages/cache/src/__tests__/fixtures/models/index.ts
@@ -1,1 +1,2 @@
+export * from './test-2.model';
 export * from './test.model';

--- a/packages/cache/src/__tests__/fixtures/models/test-2.model.ts
+++ b/packages/cache/src/__tests__/fixtures/models/test-2.model.ts
@@ -1,0 +1,17 @@
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class Test2 extends Entity {
+  @property({
+    type: 'number',
+    id: true,
+  })
+  id: number;
+  @property({
+    type: 'string',
+  })
+  name: string;
+  constructor(data?: Partial<Test2>) {
+    super(data);
+  }
+}

--- a/packages/cache/src/__tests__/fixtures/repositories/test-2-with-mixin.repository.ts
+++ b/packages/cache/src/__tests__/fixtures/repositories/test-2-with-mixin.repository.ts
@@ -1,10 +1,10 @@
-import {DefaultCrudRepository, juggler} from '@loopback/repository';
-import {Test} from '../models';
 import {inject} from '@loopback/core';
+import {DefaultCrudRepository, juggler} from '@loopback/repository';
 import {CacheMixin} from '../../../mixins';
+import {Test2} from '../models';
 
 export class Test2WithMixinRepository extends CacheMixin(
-  DefaultCrudRepository<Test, number, {}>,
+  DefaultCrudRepository<Test2, number, {}>,
   {
     invalidationTags: ['TestTag', 'Test2Tag'],
     cachedItemTags: ['Test2Tag'],
@@ -12,6 +12,6 @@ export class Test2WithMixinRepository extends CacheMixin(
 ) {
   cacheIdentifier = 'testRepo2';
   constructor(@inject('datasources.memorydb2') dataSource: juggler.DataSource) {
-    super(Test, dataSource);
+    super(Test2, dataSource);
   }
 }

--- a/packages/cache/src/__tests__/helpers/test-builder.ts
+++ b/packages/cache/src/__tests__/helpers/test-builder.ts
@@ -680,6 +680,12 @@ export function repoTestBuilder(
             cacheStoreSetSpy: sinon.SinonSpy,
             secondRepo?: DefaultCrudRepository<Test, number, {}>,
           ) {
+            const existing1 = await repo.findById(1);
+            await flushPromises();
+            expect(existing1).to.match(mockData[0]);
+            const existing2 = await repo.findById(2);
+            await flushPromises();
+            expect(existing2).to.match(mockData[1]);
             await repo.updateById(1, {name: 'test-new-1'});
             await flushPromises();
             await repo.updateById(2, {name: 'test-new-2'});

--- a/packages/cache/src/__tests__/integration/cache-repository.mixin.integration.ts
+++ b/packages/cache/src/__tests__/integration/cache-repository.mixin.integration.ts
@@ -27,12 +27,6 @@ describe('CachedRepository: Integration', () => {
   let cacheStoreGetSpy: sinon.SinonSpy;
   let cacheStoreSetSpy: sinon.SinonSpy;
   let clock: sinon.SinonFakeTimers | undefined = undefined;
-  let mochaContext: Mocha.Context;
-
-  before(function () {
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this, @typescript-eslint/no-this-alias
-    mochaContext = this;
-  });
 
   beforeEach(async () => {
     setupEnv();
@@ -72,9 +66,6 @@ describe('CachedRepository: Integration', () => {
     describe(testSuite.title, () => {
       testSuite.tests.forEach(test => {
         it(test.title, async function () {
-          if (test.timeout) {
-            mochaContext.timeout(test.timeout);
-          }
           await test.test(
             repo,
             mockData,

--- a/packages/cache/src/services/cache.service.ts
+++ b/packages/cache/src/services/cache.service.ts
@@ -204,27 +204,6 @@ export class CacheService implements ICacheService {
     await this.store.setMany([prefixDeletion, ...tagDeletions]);
   }
 
-  /**
-   * This function removes invalidatations of cache entries based on a given prefix and tags.
-   * @param {string} prefix - The `prefix` parameter is a string that is used to identify a group of
-   * items that need to be uninvalidated.
-   * @param {string[]} [tags] - The `tags` parameter in the `uninvalidate` method is an optional
-   * parameter of type `string[]`. It is an array of strings that represent tags that were invalidated. If
-   * this parameter is provided when calling the method, the corresponding tags will be uninvalidated along
-   * with the specified prefix. If the `
-   */
-  private async uninvalidate(prefix: string, tags?: string[]): Promise<void> {
-    const prefixDeletion = this.invalidatePrefix(prefix);
-    let tagDeletions: [string, number, number][] = [];
-    if (tags) {
-      tagDeletions = this.invalidateTags(tags);
-    }
-    await this.store.deleteMany([
-      prefixDeletion[0],
-      ...tagDeletions.map(record => record[0]),
-    ]);
-  }
-
   private invalidatePrefix(prefix: string): [string, number, number] {
     const deletionKey = this.buildKey(this.deletionMarkerPrefix, prefix);
     return [deletionKey, Date.now(), this.configuration.ttl];

--- a/packages/cache/src/services/cache.service.ts
+++ b/packages/cache/src/services/cache.service.ts
@@ -161,11 +161,13 @@ export class CacheService implements ICacheService {
       }
     }
     const result = await fn(...args);
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.saveInCache(prefix, key, options?.tags ?? [], result, cacheOptions)
-      .catch(err => this.logger.error(err.message))
-      // to make sure new calls for same prefix or tags are not invalidated
-      .then(_ => this.uninvalidate(prefix, options?.tags));
+    this.saveInCache(
+      prefix,
+      key,
+      options?.tags ?? [],
+      result,
+      cacheOptions,
+    ).catch(err => this.logger.error(err.message));
     return result;
   }
 


### PR DESCRIPTION
## Description

- removed the `uninvalidate` call as it can undo invalidation on any subsequent get, even with a different filter.
- added test case to cover this exact scenario
- refactored the tests a bit for better timeout handling

Fixes GH-2249

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
