### PR TITLE
fix(cli): correct Redis datasource name in test-helper, nycrc, and datasource files

### DIFF
--- a/packages/cli/src/generators/datasource/templates/name.datasource.ts.tpl
+++ b/packages/cli/src/generators/datasource/templates/name.datasource.ts.tpl
@@ -13,7 +13,11 @@ const DEFAULT_DB_IDLE_TIMEOUT_MILLIS = 60000;
 const DEFAULT_DB_CONNECTION_TIMEOUT_MILLIS = 2000;
 
 const config = {
+  <% if (project.serviceDependency && project.baseServiceStoreName ) { -%>
+  name: <%= project.baseServiceStoreName  %>,
+  <% }else{ -%>
   name: '<%= project.datasourceName  %>',
+  <% } -%>	
   connector: '<%= project.datasourceConnectorName  %>',
   host: process.env.DB_HOST,
   port: process.env.DB_PORT,
@@ -45,7 +49,12 @@ juggler.DataSource
   static readonly defaultConfig = config;
 
   constructor(
+
+  <% if (project.serviceDependency && project.baseServiceStoreName ) { -%>
+    @inject(`datasources.config.${<%= project.baseServiceStoreName %>}`, {optional: true})
+  <% }else{ -%>
     @inject('datasources.config.<%= project.datasourceName %>', {optional: true})
+    <% } -%>	
     dsConfig: object = config,
   ) {
     if (!!+(process.env.ENABLE_DB_CONNECTION_POOLING ?? 0)) {

--- a/packages/cli/src/generators/datasource/templates/redis.datasource.ts.tpl
+++ b/packages/cli/src/generators/datasource/templates/redis.datasource.ts.tpl
@@ -8,7 +8,13 @@ import {AuthCacheSourceName} from '@sourceloop/core';
 <% } -%>
 
 const config = {
+  <% if (project.serviceDependency && project.baseServiceCacheName ) { -%>
+  name: <%= project.baseServiceCacheName %>,
+  <% } else if (project.facade) { -%>
+  name: AuthCacheSourceName,
+  <% }else{ -%>
   name: process.env.REDIS_NAME,
+  <% } -%>	
   connector: 'kv-redis',
   host: process.env.REDIS_HOST,
   port: process.env.REDIS_PORT,
@@ -49,11 +55,19 @@ export class RedisDataSource
     static dataSourceName = <%= project.baseServiceCacheName %>;
     <% } else if (project.facade) { -%>
     static dataSourceName = AuthCacheSourceName;
-    <% } -%>
+    <% }else{ -%>
+    static dataSourceName = process.env.REDIS_NAME;
+    <% } -%>	
   static readonly defaultConfig = config;
 
   constructor(
+    <% if (project.serviceDependency && project.baseServiceCacheName ) { -%>
+    @inject(`datasources.config.${<%= project.baseServiceCacheName %>}`, {optional: true})
+    <% } else if (project.facade) { -%>
+    @inject(`datasources.config.${AuthCacheSourceName}`, {optional: true})
+    <% }else{ -%>
     @inject(`datasources.config.${process.env.REDIS_NAME}`, {optional: true})
+    <% } -%>	
     dsConfig: AnyObject = config,
   ) {
     if (

--- a/packages/cli/src/generators/microservice/index.ts
+++ b/packages/cli/src/generators/microservice/index.ts
@@ -203,10 +203,9 @@ export default class MicroserviceGenerator extends AppGenerator<MicroserviceOpti
         const redisDsPresent = baseServiceDSList.filter(
           ds => ds.type === 'cache',
         );
-
-        this.projectInfo.baseServiceCacheName = redisDsPresent.length
-          ? 'redis'
-          : undefined;
+        this.projectInfo.baseServiceCacheName =
+          redisDsPresent[0]?.name ||
+          (redisDsPresent.length ? 'redis' : undefined);
       }
       this.destinationRoot(join(type, this.options.name ?? DEFAULT_NAME));
       this.projectInfo.dependencies = appendDependencies(

--- a/packages/cli/src/generators/microservice/templates/.nycrc
+++ b/packages/cli/src/generators/microservice/templates/.nycrc
@@ -1,5 +1,9 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "reporter": ["html", "text-summary"]
+  "include": ["dist"],
+  "exclude": ["dist/__tests__/", "dist/index.js"],
+  "extension": [".js", ".ts"],
+  "reporter": ["text", "html", "json"],
+  "exclude-after-remap": false,
+  "check-coverage": true,
+  "lines": 80
 }

--- a/packages/cli/src/generators/microservice/templates/src/__tests__/acceptance/test-helper.ts.ejs
+++ b/packages/cli/src/generators/microservice/templates/src/__tests__/acceptance/test-helper.ts.ejs
@@ -7,6 +7,34 @@ import {
 <% if (project.facade) { -%>
 import {RateLimitSecurityBindings} from 'loopback4-ratelimiter';
 <% } -%>
+<%
+  const importMap = {};
+
+  if (project.baseServiceDSList) {
+    for (const ds of project.baseServiceDSList) {
+      if (ds.name && ds.fileName) {
+        importMap[ds.fileName] = importMap[ds.fileName] || new Set();
+        importMap[ds.fileName].add(ds.name);
+      }
+    }
+  }
+
+  if (project.serviceDependency && project.baseServiceCacheName) {
+    const redis = project.baseServiceCacheName;
+    importMap[redis] = importMap[redis] || new Set();
+    importMap[redis].add(project.baseServiceCacheName);
+  }
+
+  for (const [fileName, namesSet] of Object.entries(importMap)) {
+    const names = Array.from(namesSet);
+-%>
+import {<%= names.join(', ') %>} from '@sourceloop/<%= project.serviceDependency %>';
+<% } %>
+<% if (project.facade) { -%>
+import {AuthCacheSourceName} from '@sourceloop/core';
+<% } -%>
+
+
 
 export async function setupApplication(): Promise<AppWithClient> {
   const restConfig = givenHttpServerConfig({
@@ -23,21 +51,41 @@ export async function setupApplication(): Promise<AppWithClient> {
   });
 
   <% if(project.baseServiceDSList) { -%>
-  <% for(let i=0; i< project.baseServiceDSList.length; i++) {-%>
-    app.bind('datasources.config.db').to({
-      name: 'db',
-      connector: 'memory',
-    });
+    <% for(let i=0; i< project.baseServiceDSList.length; i++) { 
+      const ds = project.baseServiceDSList[i]; -%>
+      <% if (ds.name) { -%>
+        app.bind(`datasources.config.${<%= ds.name %>}`).to({
+          name: '<%= ds.name %>',
+          connector: 'memory',
+        });
+        <% }else{ -%>
+          app.bind('datasources.config.db').to({
+            name: 'db',
+            connector: 'memory',
+          });
+        <% } -%>	
     <% } -%>
   <% } -%>
+  
+  
 
 
-  <% if (project.facade || project.baseServiceCacheName) { -%>
+  <% if (project.serviceDependency && project.baseServiceCacheName ) { -%>
+    app.bind(`datasources.config.${<%= project.baseServiceCacheName %>}`).to({
+      name: <%= project.baseServiceCacheName %>,
+      connector: 'kv-memory',
+    });
+    <% } else if (project.facade) { -%>
+    app.bind(`datasources.config.${AuthCacheSourceName}`).to({
+      name: AuthCacheSourceName,
+      connector: 'kv-memory',
+    });
+    <% }else{ -%>   
     app.bind(`datasources.config.${process.env.REDIS_NAME}`).to({
       name: process.env.REDIS_NAME,
       connector: 'kv-memory',
     });
-  <% } -%>
+    <% } -%>	
 
   <% if (project.facade) { -%>
     app.bind(RateLimitSecurityBindings.RATELIMIT_SECURITY_ACTION).to(async () => {


### PR DESCRIPTION
changes made are as follows:
- Fixed incorrect Redis datasource name in test-helper.ts
- Ensured proper naming in generated datasource files
- Corrected .nycrc file generation

2285

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
