### PR TITLE
refactor(cli): Refactor CLI Command: Remove Angular/React Non-Scaffold Commands

### DIFF
--- a/packages/cli/src/utilities/file-generator.ts
+++ b/packages/cli/src/utilities/file-generator.ts
@@ -8,6 +8,65 @@ export class FileGenerator {
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, {recursive: true});
     fs.writeFileSync(filePath, content, 'utf-8');
   }
+  public generateReadme(framework?: 'angular' | 'react' | 'backend'): string {
+    const cliCommands =
+      framework === 'angular' ||
+      framework === 'react' ||
+      framework === 'backend'
+        ? `
+\`\`\`bash
+
+# Scaffold new projects
+sl ${framework}:scaffold my-new-project
+
+\`\`\`
+`
+        : `
+\`\`\`bash
+# Scaffold a new ARC monorepo
+sl scaffold my-monorepo
+
+# Add a microservice
+sl microservice auth-service
+
+# Update dependencies
+sl update
+\`\`\`
+`;
+
+    return `# MCP Configuration
+
+This project has been configured with Model Context Protocol (MCP) support.
+
+## Overview
+
+MCP enables AI assistants (like Claude Code) to interact with your project through a standardized interface. It allows AI to:
+- Generate components, services, and other code artifacts
+- Scaffold new features
+- Update configuration files
+- Provide project-specific assistance
+
+## Usage
+
+### In Claude Code
+1. Open this project in an MCP-compatible IDE.
+2. The AI will automatically detect the configuration.
+3. You can ask:
+   - "Generate a new component called UserProfile"
+   - "Create a service for authentication"
+   - "Update the API base URL"
+
+### Manual CLI Usage
+${cliCommands}
+
+## Configuration
+
+- File: \`.claude/mcp.json\`
+- Customizable: timeouts, env variables, command args
+
+Docs: https://docs.anthropic.com/claude/docs/mcp
+`;
+  }
 
   removeModule(projectPath: string, moduleName: string): void {
     try {

--- a/packages/cli/src/utilities/mcp-injector.ts
+++ b/packages/cli/src/utilities/mcp-injector.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {FileGenerator} from './file-generator';
 
 export interface McpConfig {
   mcpServers: Record<
@@ -43,74 +44,11 @@ export class McpConfigInjector {
     );
 
     const readmePath = path.join(claudeDir, 'README.md');
-    fs.writeFileSync(readmePath, this.generateReadme(framework), 'utf-8');
+    const fg = new FileGenerator();
+    fs.writeFileSync(readmePath, fg.generateReadme(framework), 'utf-8');
 
     console.log('✅ MCP configuration added to project'); // NOSONAR
     console.log('   AI assistants can now interact with this project'); // NOSONAR
-  }
-
-  private generateReadme(framework?: 'angular' | 'react' | 'backend'): string {
-    const cliCommands =
-      framework === 'angular' ||
-      framework === 'react' ||
-      framework === 'backend'
-        ? `
-\`\`\`bash
-# Generate code
-sl ${framework}:generate --type component --name MyComponent
-
-# Scaffold new projects
-sl ${framework}:scaffold my-new-project
-
-# Update configuration
-sl ${framework}:config --help
-\`\`\`
-`
-        : `
-\`\`\`bash
-# Scaffold a new ARC monorepo
-sl scaffold my-monorepo
-
-# Add a microservice
-sl microservice auth-service
-
-# Update dependencies
-sl update
-\`\`\`
-`;
-
-    return `# MCP Configuration
-
-This project has been configured with Model Context Protocol (MCP) support.
-
-## Overview
-
-MCP enables AI assistants (like Claude Code) to interact with your project through a standardized interface. It allows AI to:
-- Generate components, services, and other code artifacts
-- Scaffold new features
-- Update configuration files
-- Provide project-specific assistance
-
-## Usage
-
-### In Claude Code
-1. Open this project in an MCP-compatible IDE.
-2. The AI will automatically detect the configuration.
-3. You can ask:
-   - "Generate a new component called UserProfile"
-   - "Create a service for authentication"
-   - "Update the API base URL"
-
-### Manual CLI Usage
-${cliCommands}
-
-## Configuration
-
-- File: \`.claude/mcp.json\`
-- Customizable: timeouts, env variables, command args
-
-Docs: https://docs.anthropic.com/claude/docs/mcp
-`;
   }
 
   hasMcpConfig(projectPath: string): boolean {


### PR DESCRIPTION
**Key Changes**

- Removed UI CLI commands:
- AngularConfig, AngularInfo, AngularGenerate
- ReactConfig, ReactInfo, ReactGenerate
- Updated MCP command list to register only required scaffold commands.