### PR TITLE
fix(all-services): add ./controllers subpath exports and update imports

### DIFF
--- a/services/bpmn-service/package.json
+++ b/services/bpmn-service/package.json
@@ -13,12 +13,19 @@
     "./sequelize": {
       "types": "./dist/repositories/sequelize/index.d.ts",
       "default": "./dist/repositories/sequelize/index.js"
+    },
+    "./controllers": {
+      "types": "./dist/controllers/index.d.ts",
+      "default": "./dist/controllers/index.js"
     }
   },
   "typesVersions": {
     "*": {
       "sequelize": [
         "./dist/repositories/sequelize/index.d.ts"
+      ],
+      "controllers": [
+        "./dist/controllers/index.d.ts"
       ]
     }
   },

--- a/services/bpmn-service/src/index.ts
+++ b/services/bpmn-service/src/index.ts
@@ -3,7 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 export * from './component';
-export * from './controllers';
 export * from './enums';
 export * from './keys';
 export * from './models';

--- a/services/search-service/package.json
+++ b/services/search-service/package.json
@@ -15,12 +15,19 @@
     ".": "./dist/index.js",
     "./sequelize": {
       "types": "./dist/repositories/sequelize/index.d.ts"
+    },
+    "./controllers": {
+      "types": "./dist/controllers/index.d.ts",
+      "default": "./dist/controllers/index.js"
     }
   },
   "typesVersions": {
     "*": {
       "sequelize": [
         "./dist/repositories/sequelize/index.d.ts"
+      ],
+      "controllers": [
+        "./dist/controllers/index.d.ts"
       ]
     }
   },

--- a/services/search-service/src/index.ts
+++ b/services/search-service/src/index.ts
@@ -7,7 +7,6 @@ export * from './keys';
 export * from './services';
 export * from './decorators';
 export * from './types';
-export * from './controllers';
 export * from './models';
 export * from './classes';
 export * from './repositories';

--- a/services/task-service/package.json
+++ b/services/task-service/package.json
@@ -19,8 +19,12 @@
       "default": "./dist/connectors/sqs/index.js"
     },
     "./http": {
-      "type": "./dist/connectors/http/index.d.ts",
+      "types": "./dist/connectors/http/index.d.ts",
       "default": "./dist/connectors/http/index.js"
+    },
+    "./controllers": {
+      "types": "./dist/controllers/index.d.ts",
+      "default": "./dist/controllers/index.js"
     }
   },
   "typesVersions": {
@@ -33,6 +37,9 @@
       ],
       "http": [
         "./dist/connectors/http/index.d.ts"
+      ],
+      "controllers": [
+        "./dist/controllers/index.d.ts"
       ]
     }
   },

--- a/services/task-service/src/commands/create-task.ts
+++ b/services/task-service/src/commands/create-task.ts
@@ -1,9 +1,6 @@
 import {Context} from '@loopback/core';
-import {
-  ExecuteWorkflowDto,
-  WorkflowController,
-  WorkflowRepository,
-} from '@sourceloop/bpmn-service';
+import {ExecuteWorkflowDto, WorkflowRepository} from '@sourceloop/bpmn-service';
+import {WorkflowController} from '@sourceloop/bpmn-service/controllers';
 import {ILogger, LOGGER} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {

--- a/services/task-service/src/connectors/http/index.ts
+++ b/services/task-service/src/connectors/http/index.ts
@@ -1,6 +1,5 @@
-export * from './controllers';
 export * from './http-stream.service';
+export * from './models';
 export * from './repositories';
 export * from './services';
 export * from './task-http.component';
-export * from './models';

--- a/services/task-service/src/index.ts
+++ b/services/task-service/src/index.ts
@@ -7,7 +7,6 @@ import './load-env';
 
 export * from './commands';
 export * from './component';
-export * from './controllers';
 export * from './interfaces';
 export * from './keys';
 export * from './models';

--- a/services/task-service/src/services/event-processor.service.ts
+++ b/services/task-service/src/services/event-processor.service.ts
@@ -1,10 +1,7 @@
 import {Context, inject} from '@loopback/core';
 import {AnyObject} from '@loopback/repository';
-import {
-  ExecuteWorkflowDto,
-  WorkflowController,
-  WorkflowRepository,
-} from '@sourceloop/bpmn-service';
+import {ExecuteWorkflowDto, WorkflowRepository} from '@sourceloop/bpmn-service';
+import {WorkflowController} from '@sourceloop/bpmn-service/controllers';
 import {ILogger, LOGGER} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {IEvent, IEventProcessor, IIncomingConnector} from '../interfaces';

--- a/services/video-conferencing-service/package.json
+++ b/services/video-conferencing-service/package.json
@@ -15,12 +15,19 @@
     ".": "./dist/index.js",
     "./sequelize": {
       "types": "./dist/repositories/sequelize/index.d.ts"
+    },
+    "./controllers": {
+      "types": "./dist/controllers/index.d.ts",
+      "default": "./dist/controllers/index.js"
     }
   },
   "typesVersions": {
     "*": {
       "sequelize": [
         "./dist/repositories/sequelize/index.d.ts"
+      ],
+      "controllers": [
+        "./dist/controllers/index.d.ts"
       ]
     }
   },

--- a/services/video-conferencing-service/src/index.ts
+++ b/services/video-conferencing-service/src/index.ts
@@ -4,11 +4,10 @@
 // https://opensource.org/licenses/MIT
 
 export * from './component';
-export * from './controllers';
 export * from './enums';
 export * from './keys';
 export * from './models';
 export * from './providers';
 export * from './repositories';
-export * from './types';
 export * from './services';
+export * from './types';


### PR DESCRIPTION
Add ./controllers subpath export to package.json for bpmn-service, video-conferencing-service, task-service, and search-service.

BREAKING CHANGE:
Yes
This pull request primarily updates how the `controllers` module is exported and referenced across multiple services. The changes improve module resolution by adding explicit subpath exports for `controllers` in each service's `package.json`, and update import statements to use these new subpath exports. Additionally, unnecessary wildcard exports of `controllers` are removed from several `index.ts` files, resulting in a cleaner and more maintainable codebase.

**Module export improvements:**

* Added explicit subpath exports for `controllers` in the `exports` and `typesVersions` sections of `package.json` for `bpmn-service`, `search-service`, `task-service`, and `video-conferencing-service`, enabling consumers to import controllers directly via the subpath. [[1]](diffhunk://#diff-a66feffc7734dba63bbdbac9ccd840175e0326bbc094fd2e4a490ec6e1bf62f7R16-R28) [[2]](diffhunk://#diff-1880d181863410fc6563ea65961240455ad1cdb902a0af72ea7da86b712b47eeR18-R30) [[3]](diffhunk://#diff-fca9030d32d79c6a99c6e95f0ead187e75c2259176278fc9085c4909137b883fL22-R27) [[4]](diffhunk://#diff-fca9030d32d79c6a99c6e95f0ead187e75c2259176278fc9085c4909137b883fR40-R42) [[5]](diffhunk://#diff-105ba72f1e7a0da1f379d2a5bc0057bbea1cb47d9fcf7308803352e378bb00a2R18-R30)

**Codebase cleanup:**

* Removed wildcard exports of `controllers` from the main `index.ts` files in `bpmn-service`, `search-service`, `task-service`, and `video-conferencing-service` to avoid unnecessary exposure and potential naming conflicts. [[1]](diffhunk://#diff-73b6c6fe2a69eae370b663340b4eaa9e59abb016458ce9b2754f5429199ad048L6) [[2]](diffhunk://#diff-592f1e32c1f350e2f1a47859e7032f4f8702b6eb334e705de1ecb9b77d5143f3L10) [[3]](diffhunk://#diff-0bda0fce9e232c15ec3580fe37317294d617751f2bd44a2babf3ba78932920e1L10) [[4]](diffhunk://#diff-e577da818d24f293cd257bba95d780feaabef5bf328fd21b7baa7dc8cbec408dL7-R13)
* Removed wildcard export of `controllers` from `task-service/src/connectors/http/index.ts` for better modularity.

**Import updates for new subpath:**

* Updated imports in `task-service/src/commands/create-task.ts` and `task-service/src/services/event-processor.service.ts` to use the new subpath export for `WorkflowController` from `@sourceloop/bpmn-service/controllers`. [[1]](diffhunk://#diff-e3a94dd26f6fd0d88dbc2a71aff033b27295a9ee6f4b5b4306a62884a80dc9d0L2-R3) [[2]](diffhunk://#diff-900c3d72c8bb4a0a8c6b2b7949602dc979b075ae7e48ba6722e29a44f3995e36L3-R4)