### PR TITLE
fix(cli): fix incorrect redis data source naming

### DIFF
--- a/packages/cli/src/generators/microservice/index.ts
+++ b/packages/cli/src/generators/microservice/index.ts
@@ -213,7 +213,7 @@ export default class MicroserviceGenerator extends AppGenerator<MicroserviceOpti
         );
 
         this.projectInfo.baseServiceCacheName = redisDsPresent.length
-          ? 'redis'
+          ? redisDsPresent[0].name
           : undefined;
       }
       this.destinationRoot(join(type, this.options.name ?? DEFAULT_NAME));

--- a/packages/cli/src/generators/microservice/templates/src/__tests__/acceptance/test-helper.ts.ejs
+++ b/packages/cli/src/generators/microservice/templates/src/__tests__/acceptance/test-helper.ts.ejs
@@ -58,7 +58,7 @@ function setUpEnv() {
   process.env.ENABLE_TRACING = '0';
   process.env.ENABLE_OBF = '0';
   <% if (project.facade || project.baseServiceCacheName) { -%>
-  process.env.REDIS_NAME = 'redis';
+  process.env.REDIS_NAME = '<%= project.baseServiceCacheName || "redis" %>';
   <% } -%>
   process.env.HOST='localhost';
 }


### PR DESCRIPTION
fix incorrect redis data source naming

GH-2285

## Description

Incorrect Redis Data Source Naming and Test Helper Generation in CLI


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine

### Build passed:

<img width="856" height="283" alt="Screenshot 2026-08-11 at 12 11 12 PM" src="https://github.com/user-attachments/assets/3ad0e66c-c347-41ef-b443-2f2ad44a672f" />
