### PR TITLE
refactor(cli): exclude microservice dockerfile template from sonar

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,6 +1,6 @@
 # Path to sources
 sonar.sources=.
-sonar.exclusions=api-docs/**,**/dist/**
+sonar.exclusions=api-docs/**,**/dist/**,packages/cli/src/generators/microservice/templates/Dockerfile
 #sonar.inclusions=packages/**/src/**
 
 # Path to tests

--- a/packages/cli/src/generators/microservice/templates/Dockerfile
+++ b/packages/cli/src/generators/microservice/templates/Dockerfile
@@ -10,14 +10,14 @@ ARG FROM_FOLDER
 # This command is used to install some dependencies in the Docker image.
 # Nessasary for running node-prune and npm install
 RUN  apk update &&  apk add --no-cache --virtual .gyp \
-    python3 \
-    make \
-    g++ \
     bash \
-    curl
+    curl \
+    g++ \
+    make \
+    python3
 
 # This is used to download and install the `node-prune` tool in the Docker image.
-RUN curl -sfL https://gobinaries.com/tj/node-prune | bash -s -- -b /usr/local/bin # NOSONAR
+RUN curl -sfL https://gobinaries.com/tj/node-prune | bash -s -- -b /usr/local/bin
 
 # Set to a non-root built-in user `node`
 USER node


### PR DESCRIPTION
## Description

Excludes the microservice generator's `Dockerfile` template from SonarCloud analysis and tidies the template accordingly. This is a chore/refactor with no functional impact on the generated code.

## Changes

- **`.sonarcloud.properties`** — added `packages/cli/src/generators/microservice/templates/Dockerfile` to `sonar.exclusions`.
- **`packages/cli/src/generators/microservice/templates/Dockerfile`**:
  - Sorted the `apk add` build dependencies alphabetically (`bash`, `curl`, `g++`, `make`, `python3`) for consistency.
  - Removed the now-redundant `# NOSONAR` suppression from the `node-prune` install command, since the file is excluded from analysis at the project level.

## Type of change

- [x] Refactor / chore (no functional change)

## Checklist

- [x] No functional/behavioral change to generated output
- [x] Sonar exclusion path verified against the template location